### PR TITLE
Update OCP version to 4.18

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ inputs:
   ocpReleaseLevel:
     description: 'The release level of OpenShift to use'
     required: false
-    default: '4.17'
+    default: '4.18'
   installOLM:
     description: 'Install the Operator Lifecycle Manager'
     required: false


### PR DESCRIPTION
https://access.redhat.com/support/policy/updates/openshift

OCP 4.18 is now the latest GA version so lets bump the default value.