### PR TITLE
Add OLM auto-updater YAML

### DIFF
--- a/.github/workflows/olm-update.yml
+++ b/.github/workflows/olm-update.yml
@@ -1,0 +1,33 @@
+name: Update OLM Version Nightly
+on:
+  schedule:
+    - cron: '0 2 * * *' # Every day at 2am UTC
+  workflow_dispatch:
+jobs:
+  update-olm-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get latest OLM release version
+        id: get_olm_version
+        run: |
+          latest=$(curl -s https://api.github.com/repos/operator-framework/operator-lifecycle-manager/releases/latest | jq -r .tag_name)
+          echo "Latest OLM version: $latest"
+          echo "olm_version=$latest" >> $GITHUB_OUTPUT
+
+      - name: Update OLM version in install-olm.sh
+        run: |
+          version=${{ steps.get_olm_version.outputs.olm_version }}
+          sed -i.bak -E "s/OLM_VERSION=\"v[0-9]+\.[0-9]+\.[0-9]+\"/OLM_VERSION=\"$version\"/" scripts/install-olm.sh
+          rm scripts/install-olm.sh.bak
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "Update OLM version to ${{ steps.get_olm_version.outputs.olm_version }}"
+          title: "Update OLM version to ${{ steps.get_olm_version.outputs.olm_version }}"
+          body: "Automated PR to update OLM version in install-olm.sh to the latest release."
+          branch: "update-olm-version-${{ steps.get_olm_version.outputs.olm_version }}"
+          delete-branch: true


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the update of the OLM (Operator Lifecycle Manager) version in the `install-olm.sh` script. The workflow runs nightly and creates a pull request with the updated version.

### New GitHub Actions Workflow:
* `.github/workflows/olm-update.yml`: Added a workflow named "Update OLM Version Nightly" that:
  - Runs daily at 2 AM UTC or can be manually triggered.
  - Fetches the latest OLM release version from the GitHub API.
  - Updates the `OLM_VERSION` variable in the `scripts/install-olm.sh` script.
  - Creates a pull request with the updated version, including a commit message, title, and description.