### PR TITLE
Switch to matrix for PRs

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -1,42 +1,26 @@
 ---
-  name: Test Changes
-  
-  'on':
-    push:
-      branches: [main]
-    pull_request:
-      branches: [main]
-  
-  jobs:
-    run-k8s-x86:
-      runs-on: ubuntu-22.04
-      env:
-        SHELL: /bin/bash
-      steps:
-        - name: Checkout the code
-          uses: actions/checkout@v4
+name: Test Changes
 
-        - name: Run the action
-          uses: ./
+'on':
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 2 * * *' # Nightly at 2AM UTC
+  workflow_dispatch:
 
-    run-k8s-arm64:
-      runs-on: ubuntu-22.04-arm
-      env:
-        SHELL: /bin/bash
-      steps:
-        - name: Checkout the code
-          uses: actions/checkout@v4
+jobs:
+  run-quick-k8s:
+    runs-on: ${{ matrix.os }}
+    env:
+      SHELL: /bin/bash
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-22.04-arm, ubuntu-24.04, ubuntu-24.04-arm, macos-13]
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
 
-        - name: Run the action
-          uses: ./
-
-    run-k8s-macos:
-      runs-on: macos-13
-      env:
-        SHELL: /bin/bash
-      steps:
-        - name: Checkout the code
-          uses: actions/checkout@v4
-
-        - name: Run the action
-          uses: ./
+      - name: Run the action
+        uses: ./


### PR DESCRIPTION
The matrix should include all of our _supported_ runner images.

### Workflow improvements:

* Introduced a `schedule` trigger to run the workflow nightly at 2 AM UTC and enabled manual `workflow_dispatch` for on-demand execution.
* Consolidated the previous `run-k8s-x86`, `run-k8s-arm64`, and `run-k8s-macos` jobs into a single `run-quick-k8s` job using a matrix strategy. The matrix now supports multiple operating systems, including `ubuntu-22.04`, `ubuntu-22.04-arm`, `ubuntu-24.04`, `ubuntu-24.04-arm`, and `macos-13`.