### PR TITLE
Add cmd checks to the scripts for safeguarding

### DIFF
--- a/scripts/bootstrap-clients.sh
+++ b/scripts/bootstrap-clients.sh
@@ -2,6 +2,14 @@
 # shellcheck disable=SC2207
 
 # download the latest openshift client at a certain release level
+
+for cmd in curl tar jq sort; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: $cmd is not installed." >&2
+    exit 1
+  fi
+done
+
 RELEASE_LEVEL=$1
 ARCH=$2
 VERSIONS=($(sudo curl -sH 'Accept: application/json' "https://api.openshift.com/api/upgrades_info/v1/graph?channel=stable-${RELEASE_LEVEL}&arch=${ARCH}" | jq -r '.nodes[].version' | sort))

--- a/scripts/bootstrap-docker.sh
+++ b/scripts/bootstrap-docker.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+for cmd in curl tar; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: $cmd is not installed." >&2
+    exit 1
+  fi
+done
+
 # create the docker daemon json file if it does not exist
 if [ ! -f /etc/docker/daemon.json ]; then
   echo '{}' | sudo tee /etc/docker/daemon.json

--- a/scripts/generate-kind-config.sh
+++ b/scripts/generate-kind-config.sh
@@ -3,6 +3,13 @@
 # Generate a KinD configuration file from parameters
 # Usage: generate-kind-config.sh <api-server-port> <api-server-address> <disable-default-cni> <ip-family> <default-node-image> <control-plane-nodes> <num-worker-nodes>
 
+for cmd in envsubst; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: $cmd is not installed." >&2
+    exit 1
+  fi
+done
+
 # Set the default values
 API_SERVER_PORT=$1
 API_SERVER_ADDRESS=$2

--- a/scripts/install-oc-tools.sh
+++ b/scripts/install-oc-tools.sh
@@ -2,6 +2,13 @@
 
 set -e
 
+for cmd in curl tar; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: $cmd is not installed." >&2
+    exit 1
+  fi
+done
+
 OS=$(uname -s)
 
 if [ "${OS}" == 'Linux' ]; then

--- a/scripts/install-olm.sh
+++ b/scripts/install-olm.sh
@@ -2,6 +2,13 @@
 OLM_VERSION="v0.32.0"
 echo "Installing OLM version $OLM_VERSION"
 
+for cmd in curl kubectl; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: $cmd is not installed." >&2
+    exit 1
+  fi
+done
+
 curl -L https://github.com/operator-framework/operator-lifecycle-manager/releases/download/$OLM_VERSION/install.sh -o install.sh
 chmod +x install.sh
 ./install.sh $OLM_VERSION

--- a/scripts/install-operator-sdk.sh
+++ b/scripts/install-operator-sdk.sh
@@ -3,6 +3,14 @@ set -x
 
 OPERATOR_SDK_VERSION="v1.39.2"
 
+# Pre-checks for required commands
+for cmd in curl tar; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: $cmd is not installed." >&2
+    exit 1
+  fi
+done
+
 #check if operator-sdk is installed and install it if needed
 if [[ ! -z "$(which operator-sdk 2>/dev/null)" ]]; then
 	echo "operator-sdk was found in the path, no need to install it"

--- a/scripts/remove-control-plane-taint.sh
+++ b/scripts/remove-control-plane-taint.sh
@@ -2,6 +2,14 @@
 
 # Script to remove the control plane taint from the control-plane nodes
 
+# Command precheck
+for cmd in kubectl; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: $cmd is not installed." >&2
+    exit 1
+  fi
+done
+
 # Get the list of control-plane nodes
 CONTROL_PLANE_NODES=$(kubectl get nodes --selector=node-role.kubernetes.io/control-plane -o name)
 MASTER_NODES=$(kubectl get nodes --selector=node-role.kubernetes.io/master -o name)

--- a/scripts/wait-for-pods.sh
+++ b/scripts/wait-for-pods.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+for cmd in kubectl; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: $cmd is not installed." >&2
+    exit 1
+  fi
+done
+
 timeout=1200  # 20 minutes in seconds
 elapsed=0
 interval=10


### PR DESCRIPTION
This pull request introduces command pre-checks across multiple scripts to ensure that required dependencies are installed before execution. These changes improve the robustness of the scripts by providing early feedback if any necessary tools are missing.

### Command Pre-checks Added:

* **`scripts/bootstrap-clients.sh`**: Added pre-checks for `curl`, `tar`, `jq`, and `sort` to ensure these commands are available before proceeding.

* **`scripts/bootstrap-docker.sh`**: Added pre-checks for `curl` and `tar` to verify their availability before creating the Docker daemon configuration.

* **`scripts/generate-kind-config.sh`**: Added a pre-check for `envsubst` to ensure it is installed before generating the KinD configuration file.

* **`scripts/install-oc-tools.sh`**: Added pre-checks for `curl` and `tar` to confirm their presence before installing OpenShift tools.

* **`scripts/install-olm.sh`**: Added pre-checks for `curl` and `kubectl` to ensure they are available before installing the Operator Lifecycle Manager (OLM).

* **`scripts/install-operator-sdk.sh`**: Added pre-checks for `curl` and `tar` to validate their availability before installing the Operator SDK.

* **`scripts/remove-control-plane-taint.sh`**: Added a pre-check for `kubectl` to verify its presence before removing taints from control-plane nodes.

* **`scripts/wait-for-pods.sh`**: Added a pre-check for `kubectl` to ensure it is installed before waiting for pods to be ready.