### PR TITLE
Only cleanup when Linux

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -120,6 +120,7 @@ runs:
         touch /home/runner/.docker/config
 
     - name: Free Disk Space (Ubuntu)
+      if: ${{ runner.os == 'Linux' }}
       uses: jlumbroso/free-disk-space@main
       with:
         tool-cache: false


### PR DESCRIPTION
This pull request introduces a small improvement to the `action.yml` file by adding a conditional statement to the "Free Disk Space (Ubuntu)" step. The change ensures that the step only runs when the operating system is Linux.