### PR TITLE
Add retry to OLM update

### DIFF
--- a/.github/workflows/olm-update.yml
+++ b/.github/workflows/olm-update.yml
@@ -13,17 +13,74 @@ jobs:
       - name: Get latest OLM release version
         id: get_olm_version
         run: |
-          latest=$(curl -s https://api.github.com/repos/operator-framework/operator-lifecycle-manager/releases/latest | jq -r .tag_name)
-          echo "Latest OLM version: $latest"
-          echo "olm_version=$latest" >> $GITHUB_OUTPUT
+          # Function to get OLM version with retries
+          get_olm_version() {
+            local retries=3
+            local delay=5
+            
+            for ((i=1; i<=retries; i++)); do
+              echo "Attempt $i to fetch OLM version..."
+              
+              # Make API call with timeout
+              response=$(curl -s --max-time 30 https://api.github.com/repos/operator-framework/operator-lifecycle-manager/releases/latest)
+              
+              if [ $? -eq 0 ] && [ -n "$response" ]; then
+                # Extract tag_name and validate it's not null/empty
+                version=$(echo "$response" | jq -r '.tag_name // empty')
+                
+                if [ -n "$version" ] && [ "$version" != "null" ] && [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                  echo "Successfully fetched OLM version: $version"
+                  echo "olm_version=$version" >> $GITHUB_OUTPUT
+                  return 0
+                else
+                  echo "Invalid version format: '$version'"
+                fi
+              else
+                echo "API call failed or returned empty response"
+              fi
+              
+              if [ $i -lt $retries ]; then
+                echo "Retrying in $delay seconds..."
+                sleep $delay
+              fi
+            done
+            
+            echo "Failed to fetch valid OLM version after $retries attempts"
+            exit 1
+          }
+          
+          get_olm_version
 
       - name: Update OLM version in install-olm.sh
+        id: update_version
         run: |
           version=${{ steps.get_olm_version.outputs.olm_version }}
+          
+          # Double-check the version is valid before updating
+          if [ -z "$version" ] || [ "$version" = "null" ] || ! [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Invalid OLM version '$version' - aborting update"
+            exit 1
+          fi
+          
+          echo "Updating OLM version to: $version"
+          
+          # Check if the version is already current
+          current_version=$(grep -o 'OLM_VERSION="v[0-9]\+\.[0-9]\+\.[0-9]\+"' scripts/install-olm.sh | sed 's/OLM_VERSION="\(.*\)"/\1/')
+          if [ "$current_version" = "$version" ]; then
+            echo "OLM version is already up to date ($version)"
+            echo "updated=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          # Update the version
           sed -i.bak -E "s/OLM_VERSION=\"v[0-9]+\.[0-9]+\.[0-9]+\"/OLM_VERSION=\"$version\"/" scripts/install-olm.sh
           rm scripts/install-olm.sh.bak
+          
+          echo "Successfully updated OLM version from $current_version to $version"
+          echo "updated=true" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request
+        if: steps.update_version.outputs.updated == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
           commit-message: "Update OLM version to ${{ steps.get_olm_version.outputs.olm_version }}"


### PR DESCRIPTION
This pull request enhances the OLM version update workflow by adding error handling, retries, and validation mechanisms to ensure robustness and reliability. The most important changes include introducing a retry mechanism for fetching the OLM version, validating the fetched version, and checking if the version is already up to date before proceeding with updates.

### Enhancements to OLM version fetching:
* Added a `get_olm_version` function with retry logic (up to 3 attempts) and a delay between retries to handle transient API failures when fetching the latest OLM version. The function validates the fetched version format to ensure it matches semantic versioning (e.g., `vX.Y.Z`).

### Improvements to version update process:
* Added validation to ensure the fetched OLM version is non-empty, non-null, and correctly formatted before proceeding with the update.
* Introduced a check to compare the fetched version with the current version in `scripts/install-olm.sh`. If the version is already up to date, the workflow exits early without making changes.

### Workflow logic adjustments:
* Updated the `Create Pull Request` step to conditionally execute only if the OLM version was successfully updated, preventing unnecessary pull requests.