### PR TITLE
Add calico-update YAML workflow

### DIFF
--- a/.github/workflows/calico-update.yml
+++ b/.github/workflows/calico-update.yml
@@ -1,0 +1,97 @@
+name: Update Calico Version Nightly
+on:
+  schedule:
+    - cron: '0 2 * * *' # Every day at 2am UTC
+  workflow_dispatch:
+jobs:
+  update-calico-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get latest Calico release version
+        id: get_calico_version
+        run: |
+          # Function to get Calico version with retries
+          get_calico_version() {
+            local retries=3
+            local delay=5
+
+            for ((i=1; i<=retries; i++)); do
+              echo "Attempt $i to fetch Calico version..."
+
+              # Make API call with timeout
+              response=$(curl -s --max-time 30 https://api.github.com/repos/projectcalico/calico/releases/latest)
+
+              if [ $? -eq 0 ] && [ -n "$response" ]; then
+                # Extract tag_name and validate it's not null/empty
+                version=$(echo "$response" | jq -r '.tag_name // empty')
+
+                if [ -n "$version" ] && [ "$version" != "null" ] && [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                  echo "Successfully fetched Calico version: $version"
+                  echo "calico_version=$version" >> $GITHUB_OUTPUT
+                  return 0
+                else
+                  echo "Invalid version format: '$version'"
+                fi
+              else
+                echo "API call failed or returned empty response"
+              fi
+
+              if [ $i -lt $retries ]; then
+                echo "Retrying in $delay seconds..."
+                sleep $delay
+              fi
+            done
+
+            echo "Failed to fetch valid Calico version after $retries attempts"
+            exit 1
+          }
+
+          get_calico_version
+
+      - name: Update default calicoVersion in action.yml
+        id: update_version
+        run: |
+          version=${{ steps.get_calico_version.outputs.calico_version }}
+
+          # Double-check the version is valid before updating
+          if [ -z "$version" ] || [ "$version" = "null" ] || ! [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Invalid Calico version '$version' - aborting update"
+            exit 1
+          fi
+
+          echo "Updating Calico version to: $version"
+
+          # Extract current default under the calicoVersion block
+          current_version=$(sed -n "/^  calicoVersion:$/,/^  [a-zA-Z]\+:/p" action.yml | grep -o "default: '[^']*'" | sed "s/default: '\(.*\)'/\1/")
+
+          if [ -z "$current_version" ]; then
+            echo "Could not determine current Calico version from action.yml"
+            exit 1
+          fi
+
+          if [ "$current_version" = "$version" ]; then
+            echo "Calico version is already up to date ($version)"
+            echo "updated=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Update only within the calicoVersion block
+          sed -i.bak -E "/^  calicoVersion:$/,/^  [a-zA-Z]+:/{s/(default: ')[^']+(')/\1$version\2/}" action.yml
+          rm action.yml.bak
+
+          echo "Successfully updated Calico version from $current_version to $version"
+          echo "updated=true" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        if: steps.update_version.outputs.updated == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "Update Calico version to ${{ steps.get_calico_version.outputs.calico_version }}"
+          title: "Update Calico version to ${{ steps.get_calico_version.outputs.calico_version }}"
+          body: "Automated PR to update default calicoVersion in action.yml to the latest release."
+          branch: "update-calico-version-${{ steps.get_calico_version.outputs.calico_version }}"
+          delete-branch: true
+


### PR DESCRIPTION
Similar to #26 where we added an updater workflow for OLM.  This does the same except for calico.

**Automation of Calico Version Updates:**

* Added `.github/workflows/calico-update.yml` to run nightly and on demand, automating the process of updating the default Calico version in `action.yml`.
* Implemented a robust shell script step to fetch and validate the latest Calico release version from the GitHub API, including retries and format checking.
* The workflow updates the `default` value for `calicoVersion` in `action.yml` only if a new version is available, ensuring unnecessary updates are avoided.
* If the version is updated, the workflow automatically creates a pull request with a descriptive commit message and branch name.