### PR TITLE
Add automatic version tagger

### DIFF
--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -1,0 +1,46 @@
+name: Update Major Version Tag
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  update-major-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Update major version tag
+        run: |
+          # Get the release tag (e.g., v1.2.3)
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+          echo "Release tag: $TAG_NAME"
+
+          # Extract major version (e.g., v1 from v1.2.3)
+          if [[ $TAG_NAME =~ ^v([0-9]+)\. ]]; then
+            MAJOR_VERSION="v${BASH_REMATCH[1]}"
+            echo "Major version: $MAJOR_VERSION"
+
+            # Configure git
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+
+            # Delete the major version tag locally if it exists
+            git tag -d "$MAJOR_VERSION" 2>/dev/null || true
+
+            # Create/update the major version tag to point to the release tag
+            git tag -fa "$MAJOR_VERSION" -m "Update $MAJOR_VERSION to $TAG_NAME"
+
+            # Force push the major version tag
+            git push origin "$MAJOR_VERSION" --force
+
+            echo "✅ Successfully updated $MAJOR_VERSION tag to point to $TAG_NAME"
+          else
+            echo "⚠️ Tag $TAG_NAME does not match expected format (vX.Y.Z), skipping major version update"
+          fi


### PR DESCRIPTION
Similar to:
- https://github.com/sebrandon1/ocp-doc-checker/pull/8
- https://github.com/palmsoftware/quick-ocp/pull/31

This pull request adds a new GitHub Actions workflow to automatically update the major version tag whenever a new release is published. This helps ensure that the major tag (like v1) always points to the latest release in that major version series.

Automation for release tagging:

* Added a new workflow file `.github/workflows/update-major-tag.yml` that listens for published releases and updates the corresponding major version tag (e.g., `v1`) to point to the latest release tag.