### PR TITLE
Add Red Hat status check to OCP version update workflow

### DIFF
--- a/.github/workflows/ocp-version-update.yml
+++ b/.github/workflows/ocp-version-update.yml
@@ -17,7 +17,7 @@ jobs:
         uses: palmsoftware/redhat-status@v0
         with:
           components: |
-            Red Hat OpenShift Cluster Manager
+            api.openshift.com
 
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/ocp-version-update.yml
+++ b/.github/workflows/ocp-version-update.yml
@@ -13,6 +13,12 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Check Red Hat Status
+        uses: palmsoftware/redhat-status@v0
+        with:
+          components: |
+            Red Hat OpenShift Cluster Manager
+
       - name: Checkout repository
         uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
- Add [`palmsoftware/redhat-status`](https://github.com/palmsoftware/redhat-status)`@v0` as first step in the `update-ocp-version` job
- Filters to `Red Hat OpenShift Cluster Manager` (covers api.openshift.com Cincinnati API)
- Informational only — prints status but does not fail the workflow
- Provides visibility when Red Hat API issues may cause version detection failures

## Related
- palmsoftware/quick-ocp#50