### PR TITLE
Add operator-sdk installation support

### DIFF
--- a/.github/workflows/operator-sdk-update.yml
+++ b/.github/workflows/operator-sdk-update.yml
@@ -1,0 +1,103 @@
+name: Update operator-sdk Version Nightly
+on:
+  schedule:
+    - cron: '0 4 * * *' # Every day at 4am UTC
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  update-operator-sdk-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Get latest operator-sdk release version
+        id: get_operator_sdk_version
+        run: |
+          # Function to get operator-sdk version with retries
+          get_operator_sdk_version() {
+            local retries=3
+            local delay=5
+
+            for ((i=1; i<=retries; i++)); do
+              echo "Attempt $i to fetch operator-sdk version..."
+
+              # Make API call with timeout
+              response=$(curl -s --max-time 30 https://api.github.com/repos/operator-framework/operator-sdk/releases/latest)
+
+              if [ $? -eq 0 ] && [ -n "$response" ]; then
+                # Extract tag_name and validate it's not null/empty
+                version=$(echo "$response" | jq -r '.tag_name // empty')
+
+                if [ -n "$version" ] && [ "$version" != "null" ] && [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                  echo "Successfully fetched operator-sdk version: $version"
+                  echo "operator_sdk_version=$version" >> $GITHUB_OUTPUT
+                  return 0
+                else
+                  echo "Invalid version format: '$version'"
+                fi
+              else
+                echo "API call failed or returned empty response"
+              fi
+
+              if [ $i -lt $retries ]; then
+                echo "Retrying in $delay seconds..."
+                sleep $delay
+              fi
+            done
+
+            echo "Failed to fetch valid operator-sdk version after $retries attempts"
+            exit 1
+          }
+
+          get_operator_sdk_version
+
+      - name: Update default operatorSdkVersion in action.yml
+        id: update_version
+        run: |
+          version=${{ steps.get_operator_sdk_version.outputs.operator_sdk_version }}
+
+          # Double-check the version is valid before updating
+          if [ -z "$version" ] || [ "$version" = "null" ] || ! [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Invalid operator-sdk version '$version' - aborting update"
+            exit 1
+          fi
+
+          echo "Updating operator-sdk version to: $version"
+
+          # Extract current default under the operatorSdkVersion block
+          current_version=$(sed -n "/^  operatorSdkVersion:$/,/^  [a-zA-Z]\+:/p" action.yml | grep -o "default: '[^']*'" | sed "s/default: '\(.*\)'/\1/")
+
+          if [ -z "$current_version" ]; then
+            echo "Could not determine current operator-sdk version from action.yml"
+            exit 1
+          fi
+
+          if [ "$current_version" = "$version" ]; then
+            echo "operator-sdk version is already up to date ($version)"
+            echo "updated=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Update only within the operatorSdkVersion block
+          sed -i.bak -E "/^  operatorSdkVersion:$/,/^  [a-zA-Z]+:/{s/(default: ')[^']+(')/\1$version\2/}" action.yml
+          rm action.yml.bak
+
+          echo "Successfully updated operator-sdk version from $current_version to $version"
+          echo "updated=true" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        if: steps.update_version.outputs.updated == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+          commit-message: "Update operator-sdk version to ${{ steps.get_operator_sdk_version.outputs.operator_sdk_version }}"
+          title: "Update operator-sdk version to ${{ steps.get_operator_sdk_version.outputs.operator_sdk_version }}"
+          body: "Automated PR to update default operatorSdkVersion in action.yml to the latest release."
+          branch: "update-operator-sdk-version-${{ steps.get_operator_sdk_version.outputs.operator_sdk_version }}"
+          delete-branch: true

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -412,3 +412,29 @@ jobs:
           echo "Testing kubectl top nodes..."
           kubectl top nodes || echo "Metrics may need more time to populate"
           echo "metrics-server installation verified!"
+
+  # Test operator-sdk installation
+  test-operator-sdk:
+    needs: lint
+    if: ${{ needs.lint.result == 'success' }}
+    runs-on: ubuntu-24.04
+    env:
+      SHELL: /bin/bash
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v6
+
+      - name: Run the action with operator-sdk
+        uses: ./
+        with:
+          clusterProvider: kind
+          installOperatorSdk: true
+          waitForPodsReady: true
+          installOLM: false
+          installIstio: false
+
+      - name: Verify operator-sdk is installed
+        run: |
+          echo "Checking operator-sdk installation..."
+          operator-sdk version
+          echo "operator-sdk installation verified!"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Update cert-manager Version Nightly](https://github.com/palmsoftware/quick-k8s/actions/workflows/cert-manager-update.yml/badge.svg)](https://github.com/palmsoftware/quick-k8s/actions/workflows/cert-manager-update.yml)
 [![Update ingress-nginx Version Nightly](https://github.com/palmsoftware/quick-k8s/actions/workflows/ingress-nginx-update.yml/badge.svg)](https://github.com/palmsoftware/quick-k8s/actions/workflows/ingress-nginx-update.yml)
 [![Update metrics-server Version Nightly](https://github.com/palmsoftware/quick-k8s/actions/workflows/metrics-server-update.yml/badge.svg)](https://github.com/palmsoftware/quick-k8s/actions/workflows/metrics-server-update.yml)
+[![Update operator-sdk Version Nightly](https://github.com/palmsoftware/quick-k8s/actions/workflows/operator-sdk-update.yml/badge.svg)](https://github.com/palmsoftware/quick-k8s/actions/workflows/operator-sdk-update.yml)
 [![Update Major Version Tag](https://github.com/palmsoftware/quick-k8s/actions/workflows/update-major-tag.yml/badge.svg)](https://github.com/palmsoftware/quick-k8s/actions/workflows/update-major-tag.yml)
 
 Github Action that will automatically create a Kubernetes cluster that lives and runs on Github Actions to allow for deployment and testing of code.
@@ -87,6 +88,8 @@ steps:
       ingressNginxVersion: v1.14.3
       installMetricsServer: false
       metricsServerVersion: v0.8.1
+      installOperatorSdk: false
+      operatorSdkVersion: v1.42.2
       removeDefaultStorageClass: false
       removeControlPlaneTaint: false
 
@@ -124,6 +127,8 @@ steps:
       ingressNginxVersion: v1.14.3
       installMetricsServer: false
       metricsServerVersion: v0.8.1
+      installOperatorSdk: false
+      operatorSdkVersion: v1.42.2
       removeDefaultStorageClass: false
       removeControlPlaneTaint: false
 ```
@@ -292,6 +297,39 @@ steps:
 - Requires approximately 50-100MB additional memory
 - Metrics API takes ~30 seconds after startup to populate
 - Automatically patched with `--kubelet-insecure-tls` for local clusters (KinD/Minikube)
+
+### Installing operator-sdk
+
+Enable operator-sdk CLI installation for building and testing Kubernetes operators:
+
+```yaml
+steps:
+  - name: Set up Quick-K8s with operator-sdk
+    uses: palmsoftware/quick-k8s@v0.0.61
+    with:
+      installOperatorSdk: true
+      operatorSdkVersion: v1.42.2
+```
+
+**Features**:
+- CLI tool for scaffolding, building, and testing Kubernetes operators
+- Supports Go, Ansible, and Helm-based operators
+- Includes scorecard testing for operator validation
+- Works with OLM for operator packaging and deployment
+
+**Example: Scaffold and test an operator**:
+```yaml
+- name: Initialize operator project
+  run: |
+    mkdir my-operator && cd my-operator
+    operator-sdk init --domain example.com --repo github.com/example/my-operator
+    operator-sdk create api --group cache --version v1alpha1 --kind Memcached --resource --controller
+```
+
+**⚠️ Resource Considerations**:
+- operator-sdk is a CLI tool only — it does not deploy any pods to the cluster
+- Requires approximately 100MB disk space for the binary
+- For full operator development workflows, consider also enabling OLM (`installOLM: true`)
 
 ### Bring Your Own CNI (Skip Calico)
 

--- a/action.yml
+++ b/action.yml
@@ -116,6 +116,14 @@ inputs:
     description: 'Comma-separated list of key=value labels to apply to worker nodes (e.g., "node-role.kubernetes.io/worker=worker,env=test")'
     required: false
     default: ''
+  installOperatorSdk:
+    description: 'Install operator-sdk CLI for building and testing Kubernetes operators'
+    required: false
+    default: 'false'
+  operatorSdkVersion:
+    description: 'The version of operator-sdk to install'
+    required: false
+    default: 'v1.42.2'
   installCalico:
     description: 'Install Calico CNI when default CNI is disabled. Set to false to bring your own CNI (e.g., Multus, OVN)'
     required: false
@@ -437,6 +445,50 @@ runs:
           attempt=$((attempt + 1))
         done
 
+    - name: Validate installOperatorSdk input
+      shell: bash
+      run: |
+        if [[ "${{ inputs.installOperatorSdk }}" != "true" && "${{ inputs.installOperatorSdk }}" != "false" ]]; then
+          echo "Invalid installOperatorSdk value: ${{ inputs.installOperatorSdk }}"
+          echo "Must be 'true' or 'false'"
+          exit 1
+        fi
+
+    - name: Validate operator-sdk version input
+      if: ${{ inputs.installOperatorSdk == 'true' }}
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        if ! [[ "${{ inputs.operatorSdkVersion }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "Invalid operator-sdk version format: ${{ inputs.operatorSdkVersion }}"
+          exit 1
+        fi
+        # Retry logic for flaky GitHub API calls with exponential backoff
+        max_attempts=5
+        attempt=1
+        delay=2
+        while [ $attempt -le $max_attempts ]; do
+          http_code=$(curl --silent --output /dev/null --write-out "%{http_code}" -L -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/operator-framework/operator-sdk/releases/tags/${{ inputs.operatorSdkVersion }})
+          if [ "$http_code" = "200" ]; then
+            echo "operator-sdk version ${{ inputs.operatorSdkVersion }} validated successfully"
+            break
+          fi
+          if [ $attempt -eq $max_attempts ]; then
+            if [ "$http_code" = "404" ]; then
+              echo "operator-sdk version ${{ inputs.operatorSdkVersion }} does not exist on GitHub"
+            else
+              echo "GitHub API failed to validate operator-sdk version ${{ inputs.operatorSdkVersion }} (HTTP $http_code after $max_attempts attempts)"
+              echo "This may be a temporary GitHub API issue - consider re-running the workflow"
+            fi
+            exit 1
+          fi
+          echo "Attempt $attempt/$max_attempts failed (HTTP $http_code), retrying in $delay seconds..."
+          sleep $delay
+          delay=$((delay * 2))
+          attempt=$((attempt + 1))
+        done
+
     - name: Validate installCalico input
       shell: bash
       run: |
@@ -676,6 +728,11 @@ runs:
       if: ${{ inputs.installMetricsServer == 'true' }}
       shell: bash
       run: ${{ github.action_path }}/scripts/install-metrics-server.sh ${{ inputs.metricsServerVersion }}
+
+    - name: Install operator-sdk
+      if: ${{ inputs.installOperatorSdk == 'true' }}
+      shell: bash
+      run: ${{ github.action_path }}/scripts/install-operator-sdk.sh ${{ inputs.operatorSdkVersion }}
 
     - name: Remove the default storage class
       if: ${{ inputs.removeDefaultStorageClass == 'true' }}

--- a/scripts/install-operator-sdk.sh
+++ b/scripts/install-operator-sdk.sh
@@ -1,20 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-OPERATOR_SDK_VERSION="${1:-v1.42.2}"
+OPERATOR_SDK_VERSION="${1:?operator-sdk version argument is required}"
 
 echo "Installing operator-sdk version $OPERATOR_SDK_VERSION"
 
-for cmd in curl chmod; do
-  if ! command -v "$cmd" >/dev/null 2>&1; then
-    echo "Error: $cmd is not installed." >&2
-    exit 1
-  fi
-done
-
-if command -v operator-sdk >/dev/null 2>&1; then
-  echo "operator-sdk is already installed: $(operator-sdk version)"
-  exit 0
+if ! command -v curl >/dev/null 2>&1; then
+  echo "Error: curl is not installed." >&2
+  exit 1
 fi
 
 ARCH="$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n "$(uname -m)" ;; esac)"

--- a/scripts/install-operator-sdk.sh
+++ b/scripts/install-operator-sdk.sh
@@ -1,54 +1,35 @@
 #!/usr/bin/env bash
-set -x
+set -euo pipefail
 
-OPERATOR_SDK_VERSION="v1.40.0"
+OPERATOR_SDK_VERSION="${1:-v1.42.2}"
 
-# Pre-checks for required commands
-for cmd in curl tar; do
+echo "Installing operator-sdk version $OPERATOR_SDK_VERSION"
+
+for cmd in curl chmod; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "Error: $cmd is not installed." >&2
     exit 1
   fi
 done
 
-#check if operator-sdk is installed and install it if needed
-if [[ -n "$(which operator-sdk 2>/dev/null)" ]]; then
-	echo "operator-sdk was found in the path, no need to install it"
+if command -v operator-sdk >/dev/null 2>&1; then
+  echo "operator-sdk is already installed: $(operator-sdk version)"
   exit 0
 fi
 
-#setting sudo
-sudo echo "setting sudo root"
-if [[ -n "$(which sw_vers 2>/dev/null)" ]]; then
-	echo "Installing operator-sdk for Mac"
-	brew install operator-sdk
-else
-	echo "Installing operator-sdk for Linux"
+ARCH="$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n "$(uname -m)" ;; esac)"
+OS="$(uname | awk '{print tolower($0)}')"
 
-	# Install operator sdk
-	## Configure platform
-	ARCH="$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n "$(uname -m)" ;; esac)"
-	OS="$(uname | awk '{print tolower($0)}')"
-	export ARCH OS
+DL_URL="https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk_${OS}_${ARCH}"
 
-	## Download executable
-	export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}
-	curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_"${OS}"_"${ARCH}"
-
-	## Download the auth key
-	gpg --keyserver keyserver.ubuntu.com --recv-keys 052996E2A20B5C7E
-
-	curl -LO ${OPERATOR_SDK_DL_URL}/checksums.txt
-	curl -LO ${OPERATOR_SDK_DL_URL}/checksums.txt.asc
-	gpg -u "Operator SDK (release) <cncf-operator-sdk@cncf.io>" --verify checksums.txt.asc
-
-	OUT=$(grep operator-sdk_"${OS}"_"${ARCH}" checksums.txt | sha256sum -c -)
-	echo "$OUT"
-	if [ "$OUT" = "operator-sdk_linux_amd64: OK" ]; then
-		chmod +x operator-sdk_"${OS}"_"${ARCH}" && sudo mv operator-sdk_"${OS}"_"${ARCH}" /usr/local/bin/operator-sdk
-		echo "operator-sdk configured"
-	else
-		echo "Error: Checksum mismatch, quitting"
-		exit 1
-	fi
+echo "Downloading operator-sdk from: $DL_URL"
+if ! curl -fL --retry 3 --retry-delay 5 -o /tmp/operator-sdk "$DL_URL"; then
+  echo "Error: Failed to download operator-sdk" >&2
+  exit 1
 fi
+
+chmod +x /tmp/operator-sdk
+sudo mv /tmp/operator-sdk /usr/local/bin/operator-sdk
+
+echo "operator-sdk $OPERATOR_SDK_VERSION installed successfully!"
+operator-sdk version


### PR DESCRIPTION
## Summary
- Rewrite `scripts/install-operator-sdk.sh` to accept version as a parameter, matching the pattern used by cert-manager, ingress-nginx, and metrics-server
- Add `installOperatorSdk` and `operatorSdkVersion` (default: v1.42.2) inputs to `action.yml` with full validation and retry logic
- Create `operator-sdk-update.yml` nightly workflow for automated version bumps
- Add `test-operator-sdk` CI job to `pre-main.yml`
- Add README documentation section, badge, and config examples

Companion PRs:
- https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3563
- https://github.com/redhat-best-practices-for-k8s/certsuite-sample-workload/pull/676

Ref: CNFCERT-1387

## Test plan
- [ ] CI `test-operator-sdk` job passes — verifies install and `operator-sdk version` output
- [ ] Existing CI jobs remain green (no regressions)
- [ ] Shellcheck passes on rewritten install script