### PR TITLE
Add k3s as a cluster provider option

### DIFF
--- a/.github/workflows/k3s-update.yml
+++ b/.github/workflows/k3s-update.yml
@@ -1,0 +1,69 @@
+name: Update k3s Version Nightly
+on:
+  schedule:
+    - cron: '0 4 * * *' # Every day at 4am UTC
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  update-k3s-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Get latest k3s release version
+        id: get_k3s_version
+        run: |
+          version=$(./scripts/get-latest-k3s-version.sh)
+          echo "k3s_version=$version" >> $GITHUB_OUTPUT
+
+      - name: Update default k3sVersion in action.yml
+        id: update_version
+        run: |
+          version="${{ steps.get_k3s_version.outputs.k3s_version }}"
+
+          # Double-check the version is valid before updating
+          if [ -z "$version" ] || [ "$version" = "null" ] || ! [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+\+k3s[0-9]+$ ]]; then
+            echo "Error: Invalid k3s version '$version' - aborting update"
+            exit 1
+          fi
+
+          echo "Updating k3s version to: $version"
+
+          # Extract current default under the k3sVersion block
+          current_version=$(sed -n "/^  k3sVersion:$/,/^  [a-zA-Z]\+:/p" action.yml | grep -o "default: '[^']*'" | sed "s/default: '\(.*\)'/\1/")
+
+          if [ -z "$current_version" ]; then
+            echo "Could not determine current k3s version from action.yml"
+            exit 1
+          fi
+
+          if [ "$current_version" = "$version" ]; then
+            echo "k3s version is already up to date ($version)"
+            echo "updated=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Update only within the k3sVersion block
+          # Escape the + in the version for sed replacement
+          escaped_version=$(echo "$version" | sed 's/+/\\+/g')
+          sed -i.bak -E "/^  k3sVersion:$/,/^  [a-zA-Z]+:/{s/(default: ')[^']+(')/\1${escaped_version}\2/}" action.yml
+          rm action.yml.bak
+
+          echo "Successfully updated k3s version from $current_version to $version"
+          echo "updated=true" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        if: steps.update_version.outputs.updated == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          commit-message: "Update k3s version to ${{ steps.get_k3s_version.outputs.k3s_version }}"
+          title: "Update k3s version to ${{ steps.get_k3s_version.outputs.k3s_version }}"
+          body: "Automated PR to update default k3sVersion in action.yml to the latest release."
+          branch: "update-k3s-version-${{ steps.get_k3s_version.outputs.k3s_version }}"
+          delete-branch: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-22.04-arm, ubuntu-24.04, ubuntu-24.04-arm]
-        provider: [kind, minikube]
+        provider: [kind, minikube, k3s]
     runs-on: ${{ matrix.os }}
     env:
       SHELL: /bin/bash
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04]
-        provider: [kind, minikube]
+        provider: [kind, minikube, k3s]
         nodes:
           - controlPlane: 1
             workers: 2
@@ -80,7 +80,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04]
-        provider: [kind, minikube]
+        provider: [kind, minikube, k3s]
     runs-on: ${{ matrix.os }}
     env:
       SHELL: /bin/bash
@@ -107,13 +107,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04]
-        provider: [kind, minikube]
+        provider: [kind, minikube, k3s]
         istio-profile: [minimal, demo, default]
         exclude:
-          # Exclude resource-heavy profiles on minikube to avoid timeouts
+          # Exclude resource-heavy profiles on minikube/k3s to avoid timeouts
           - provider: minikube
             istio-profile: demo
           - provider: minikube
+            istio-profile: default
+          - provider: k3s
+            istio-profile: demo
+          - provider: k3s
             istio-profile: default
     runs-on: ${{ matrix.os }}
     env:
@@ -144,7 +148,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04]
-        provider: [kind, minikube]
+        provider: [kind, minikube, k3s]
     runs-on: ${{ matrix.os }}
     env:
       SHELL: /bin/bash

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -38,10 +38,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-22.04-arm, ubuntu-24.04, ubuntu-24.04-arm]
-        provider: [kind, minikube]
+        provider: [kind, minikube, k3s]
         experimental: [false]
         include:
-          # macOS Intel tests (experimental)
+          # macOS Intel tests (experimental, k3s excluded - Linux only)
           - os: macos-15-intel
             provider: kind
             experimental: true
@@ -57,16 +57,17 @@ jobs:
         with:
           clusterProvider: ${{ matrix.provider }}
           waitForPodsReady: true
-          # Skip OLM, Istio, and cert-manager on macOS due to Colima networking limitations
-          installOLM: ${{ !startsWith(matrix.os, 'macos') }}
-          installIstio: ${{ !startsWith(matrix.os, 'macos') }}
+          # Skip OLM, Istio, and cert-manager on macOS (Colima limitations) and k3s (resource-heavy; tested in nightly)
+          installOLM: ${{ !startsWith(matrix.os, 'macos') && matrix.provider != 'k3s' }}
+          installIstio: ${{ !startsWith(matrix.os, 'macos') && matrix.provider != 'k3s' }}
           istioProfile: minimal
-          installCertManager: ${{ !startsWith(matrix.os, 'macos') }}
+          installCertManager: ${{ !startsWith(matrix.os, 'macos') && matrix.provider != 'k3s' }}
           removeDefaultStorageClass: true
           removeControlPlaneTaint: true
           apiServerPort: 6443
           apiServerAddress: 127.0.0.1
-          disableDefaultCni: true
+          # k3s uses built-in Flannel; disabling it requires complex CNI bootstrapping tested in nightly
+          disableDefaultCni: ${{ matrix.provider != 'k3s' }}
 
   # Test local registry functionality
   test-local-registry:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,139 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**quick-k8s** is a GitHub Action for deploying Kubernetes clusters on GitHub Actions runners. It's a composite action using shell scripts that supports KinD (Kubernetes in Docker), Minikube, and k3s as cluster providers, with optional Calico CNI, Istio service mesh, OLM (Operator Lifecycle Manager), and local Docker registry.
+
+**Target Environment**: Linux (Ubuntu 22.04/24.04, x86 and ARM64). macOS has limited support (Intel-only, requires paid runners with Docker nested virtualization).
+
+## Commands
+
+```bash
+# Lint all shell scripts with shellcheck
+make lint
+
+# Check shellcheck installation
+make tool-precheck
+
+# Clean temporary files
+make clean
+```
+
+## Architecture
+
+### Composite Action Flow
+
+The action executes in sequence via `action.yml`:
+1. **Input validation** - Validates all inputs (versions, providers, ports, node counts)
+2. **GitHub status check** - Verifies GitHub services are operational
+3. **Disk optimization** - Uses `palmsoftware/quick-cleanup` for adaptive disk management
+4. **Binary installation** - Installs KinD, Minikube, or k3s (with caching)
+5. **Cluster creation** - Creates cluster using generated or custom config
+6. **CNI installation** - Installs Calico (optional, can be skipped for bring-your-own-CNI)
+7. **Optional features** - OLM, Istio, local registry
+8. **Cleanup** - Removes temporary files
+
+### Script Organization (`/scripts/`)
+
+Each script handles a single responsibility:
+- `install-kind.sh`, `install-minikube.sh`, `install-k3s.sh` - Binary installation with fallback URLs
+- `generate-kind-config.sh` - Creates KinD YAML config from action inputs
+- `start-minikube.sh` - Starts Minikube with appropriate flags
+- `start-k3s.sh` - Starts k3s server and agent processes
+- `install-calico.sh`, `install-istio.sh`, `install-olm.sh` - Component installers
+- `setup-local-registry.sh` - Docker registry setup with cluster connectivity
+- `proactive-disk-cleanup.sh`, `pre-cluster-optimization.sh` - Disk space management
+- `check-github-status.sh` - GitHub API availability check
+
+### Version Management
+
+Nightly workflows auto-update dependency versions in `action.yml`:
+- `calico-update.yml` - Calico CNI
+- `istio-update.yml` - Istio service mesh
+- `olm-update.yml` - Operator Lifecycle Manager
+- `minikube-update.yml` - Minikube
+- `k3s-update.yml` - k3s
+
+Updates fetch latest versions from GitHub API, validate semver format, and create PRs via `peter-evans/create-pull-request`.
+
+## Key Patterns
+
+### Shell Script Standards
+
+- **Linting**: All scripts in `scripts/` must pass shellcheck
+- **Retry logic**: GitHub API calls use 3-attempt retry with exponential backoff
+- **Architecture mapping**: Converts GitHub Actions arch (`x64`, `arm64`) to tool-specific names (`amd64`, `arm64`)
+- **Fallback URLs**: Primary download + fallback for reliability
+- **Binary caching**: Binaries cached in `/tmp/` for reuse across workflow runs
+
+### Minikube CNI Constraint
+
+When `disableDefaultCni: true`, Minikube **must** use Docker runtime (not containerd). This is enforced in `start-minikube.sh`:
+```bash
+if [ "$DISABLE_CNI" = "true" ]; then
+  MINIKUBE_CMD="$MINIKUBE_CMD --container-runtime=docker"
+fi
+```
+
+### Kubernetes Version Extraction
+
+Minikube extracts K8s version from the node image tag:
+```bash
+K8S_VERSION=$(echo "$NODE_IMAGE" | sed -E 's/.*:([^@]+)@.*/\1/')
+```
+
+### k3s Specifics
+
+k3s runs as native processes (not in Docker) on the host:
+- **Version format**: `v1.33.1+k3s1` — the `+` must be URL-encoded as `%2B` in GitHub API/download URLs
+- **Linux-only**: No macOS binary exists
+- **Single control plane**: Multi-CP requires embedded etcd, not yet supported
+- **Built-in Traefik/ServiceLB disabled**: To avoid conflicts with action's ingress support
+- **Storage class**: Uses `local-path` (not `standard` like KinD/Minikube)
+- **Multi-node**: Worker nodes run as separate `k3s agent` processes with unique `--data-dir`
+
+## CI Workflows
+
+### `pre-main.yml` - Primary CI
+- Triggers: Push to main, PRs, manual dispatch
+- **Lint job blocks all other jobs** - Must pass before tests run
+- Matrix: 4 OS (ubuntu-{22,24}.04 × {x86,arm}) × 3 providers (KinD, Minikube, k3s)
+- Tests: Basic cluster, OLM, Istio, local registry, custom config, CNI skip
+
+### `nightly.yml` - Extended Testing
+- Triggers: Daily at midnight UTC
+- Multi-node cluster tests
+- Resource optimization verification
+
+## Important Implementation Details
+
+### Disk Space Management
+
+GitHub Actions free-tier runners have limited disk. The action:
+1. Uses `palmsoftware/quick-cleanup@v0` for intelligent adaptive cleanup
+2. Relocates Docker/containerd storage to larger `/mnt` partition
+3. Validates minimum 8GB free before cluster creation
+4. Runs `pre-cluster-optimization.sh` for final cleanup before cluster start
+
+### Local Registry Setup
+
+When `installLocalRegistry: true`:
+- Starts `registry:2` container on specified port
+- Connects to KinD network (for KinD provider)
+- Creates ConfigMap in `kube-public` for discoverability
+- Accessible at `localhost:<port>` from host and cluster
+
+### Input Validation
+
+All version inputs are validated:
+- Semver format check via regex
+- GitHub API validation to confirm release exists
+- Retry logic for flaky API calls
+
+## Release Process
+
+- Semantic versioning (v0.0.x)
+- `update-major-tag.yml` maintains major version tags (v0)
+- Pre-main tests must pass before release

--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@
 [![Update ingress-nginx Version Nightly](https://github.com/palmsoftware/quick-k8s/actions/workflows/ingress-nginx-update.yml/badge.svg)](https://github.com/palmsoftware/quick-k8s/actions/workflows/ingress-nginx-update.yml)
 [![Update metrics-server Version Nightly](https://github.com/palmsoftware/quick-k8s/actions/workflows/metrics-server-update.yml/badge.svg)](https://github.com/palmsoftware/quick-k8s/actions/workflows/metrics-server-update.yml)
 [![Update operator-sdk Version Nightly](https://github.com/palmsoftware/quick-k8s/actions/workflows/operator-sdk-update.yml/badge.svg)](https://github.com/palmsoftware/quick-k8s/actions/workflows/operator-sdk-update.yml)
+[![Update k3s Version Nightly](https://github.com/palmsoftware/quick-k8s/actions/workflows/k3s-update.yml/badge.svg)](https://github.com/palmsoftware/quick-k8s/actions/workflows/k3s-update.yml)
 [![Update Major Version Tag](https://github.com/palmsoftware/quick-k8s/actions/workflows/update-major-tag.yml/badge.svg)](https://github.com/palmsoftware/quick-k8s/actions/workflows/update-major-tag.yml)
 
 Github Action that will automatically create a Kubernetes cluster that lives and runs on Github Actions to allow for deployment and testing of code.
 
-Supports both **KinD** (default) and **Minikube** as cluster providers.
+Supports **KinD** (default), **Minikube**, and **k3s** as cluster providers.
 
 ## Requirements:
 
@@ -57,6 +58,28 @@ steps:
       minikubeVersion: v1.38.1
       minikubeDriver: docker
 ```
+
+### Using k3s as the Cluster Provider
+
+To use k3s for a lightweight, fast-starting cluster:
+
+```yaml
+steps:
+  - name: Set up Quick-K8s with k3s
+    uses: palmsoftware/quick-k8s@v0.0.39
+    with:
+      clusterProvider: k3s
+      k3sVersion: v1.35.3+k3s1
+      numWorkerNodes: 1
+      waitForPodsReady: true
+```
+
+**k3s Notes:**
+- Linux-only (not supported on macOS runners)
+- Single control plane node only (multi-CP not yet supported)
+- Built-in Traefik and ServiceLB are disabled by default to avoid conflicts with the action's own ingress support
+- `defaultNodeImage` and `ipFamily` inputs are ignored for k3s
+- Includes built-in local-path storage provisioner and CoreDNS
 
 ### Complete Configuration (default values shown)
 
@@ -129,6 +152,37 @@ steps:
       certManagerVersion: v1.20.2
       installIngressNginx: false
       ingressNginxVersion: v1.15.1
+      installMetricsServer: false
+      metricsServerVersion: v0.8.1
+      installOperatorSdk: false
+      operatorSdkVersion: v1.42.2
+      removeDefaultStorageClass: false
+      removeControlPlaneTaint: false
+```
+
+With k3s:
+
+```yaml
+steps:
+  - name: Set up Quick-K8s with k3s
+    uses: palmsoftware/quick-k8s@v0.0.39
+    with:
+      clusterProvider: k3s
+      k3sVersion: v1.35.3+k3s1
+      apiServerPort: 6443
+      disableDefaultCni: true
+      calicoVersion: v3.30.3
+
+      numControlPlaneNodes: 1
+      numWorkerNodes: 1
+      installOLM: false
+      installIstio: false
+      istioVersion: 1.28.1
+      istioProfile: minimal
+      installCertManager: false
+      certManagerVersion: v1.19.3
+      installIngressNginx: false
+      ingressNginxVersion: v1.14.3
       installMetricsServer: false
       metricsServerVersion: v0.8.1
       installOperatorSdk: false
@@ -437,9 +491,7 @@ steps:
 
 ## Cluster Provider Comparison
 
-### KinD vs Minikube
-
-Both cluster providers are fully supported and tested. Choose the one that best fits your needs:
+All three cluster providers are fully supported and tested. Choose the one that best fits your needs:
 
 #### KinD (Kubernetes in Docker) - **Default**
 - ✅ **Best for**: CI/CD pipelines, fast cluster creation
@@ -462,7 +514,21 @@ Both cluster providers are fully supported and tested. Choose the one that best 
   - Slightly slower startup, more complex for multi-node setups
   - When disabling default CNI (`disableDefaultCni: true`), uses docker runtime instead of containerd (Minikube requirement)
 
-**Recommendation**: Use **KinD** (default) for most CI/CD scenarios. Use **Minikube** if you need specific features or driver compatibility.
+#### k3s
+- ✅ **Best for**: Resource-constrained runners, fastest startup
+- ✅ **Advantages**:
+  - Extremely lightweight (~60MB single binary, ~512MB RAM)
+  - Fastest cluster startup (under 30 seconds)
+  - CNCF certified Kubernetes distribution
+  - Built-in local-path storage provisioner and CoreDNS
+  - Runs natively on the host (no Docker dependency for the cluster itself)
+- ⚠️ **Considerations**:
+  - Linux-only (no macOS support)
+  - Single control plane node only (multi-CP not yet supported)
+  - `defaultNodeImage` and `ipFamily` inputs are not applicable
+  - K8s version is determined by the k3s release version
+
+**Recommendation**: Use **KinD** (default) for most CI/CD scenarios. Use **k3s** for the fastest, lightest clusters on Linux runners. Use **Minikube** if you need specific features or driver compatibility.
 
 ## Network Configuration
 
@@ -514,7 +580,7 @@ This action features intelligent, adaptive disk space management that optimizes 
 
 ## History
 
-Originally built upon [KinD](https://github.com/kubernetes-sigs/kind) and tuned as part of [certsuite-sample-workload](https://github.com/redhat-best-practices-for-k8s/certsuite-sample-workload), the project now supports both KinD and [Minikube](https://github.com/kubernetes/minikube) as cluster providers.
+Originally built upon [KinD](https://github.com/kubernetes-sigs/kind) and tuned as part of [certsuite-sample-workload](https://github.com/redhat-best-practices-for-k8s/certsuite-sample-workload), the project now supports KinD, [Minikube](https://github.com/kubernetes/minikube), and [k3s](https://github.com/k3s-io/k3s) as cluster providers.
 
 This action is essentially a wrapper around best practices for deploying Kubernetes environments that run well on GitHub Actions free-tier Ubuntu runners, with intelligent resource management and optimizations for CI/CD workflows.
 

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ inputs:
     required: false
     default: 'kind'
   clusterProvider:
-    description: 'Kubernetes cluster provider (kind or minikube)'
+    description: 'Kubernetes cluster provider (kind, minikube, or k3s)'
     required: false
     default: 'kind'
   kindVersion:
@@ -52,6 +52,10 @@ inputs:
     description: 'The driver to use for Minikube (docker, podman, none)'
     required: false
     default: 'docker'
+  k3sVersion:
+    description: 'The version of k3s to use (format: v1.33.1+k3s1)'
+    required: false
+    default: 'v1.35.3+k3s1'
   calicoVersion:
     description: 'The version of Calico to use'
     required: false
@@ -147,9 +151,9 @@ runs:
     - name: Validate cluster provider input
       shell: bash
       run: |
-        if [[ "${{ inputs.clusterProvider }}" != "kind" && "${{ inputs.clusterProvider }}" != "minikube" ]]; then
+        if [[ "${{ inputs.clusterProvider }}" != "kind" && "${{ inputs.clusterProvider }}" != "minikube" && "${{ inputs.clusterProvider }}" != "k3s" ]]; then
           echo "Invalid cluster provider: ${{ inputs.clusterProvider }}"
-          echo "Must be either 'kind' or 'minikube'"
+          echo "Must be 'kind', 'minikube', or 'k3s'"
           exit 1
         fi
 
@@ -222,6 +226,54 @@ runs:
           delay=$((delay * 2))
           attempt=$((attempt + 1))
         done
+
+    - name: Validate k3s version input
+      if: ${{ inputs.clusterProvider == 'k3s' }}
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        if ! [[ "${{ inputs.k3sVersion }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+\+k3s[0-9]+$ ]]; then
+          echo "Invalid k3s version format: ${{ inputs.k3sVersion }}"
+          echo "Expected format: v1.33.1+k3s1"
+          exit 1
+        fi
+        # URL-encode the + as %2B for GitHub API
+        ENCODED_VERSION=$(echo "${{ inputs.k3sVersion }}" | sed 's/+/%2B/g')
+        # Retry logic for flaky GitHub API calls with exponential backoff
+        max_attempts=5
+        attempt=1
+        delay=2
+        while [ $attempt -le $max_attempts ]; do
+          http_code=$(curl --silent --output /dev/null --write-out "%{http_code}" -L -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/k3s-io/k3s/releases/tags/${ENCODED_VERSION}")
+          if [ "$http_code" = "200" ]; then
+            echo "k3s version ${{ inputs.k3sVersion }} validated successfully"
+            break
+          fi
+          if [ $attempt -eq $max_attempts ]; then
+            if [ "$http_code" = "404" ]; then
+              echo "k3s version ${{ inputs.k3sVersion }} does not exist on GitHub"
+            else
+              echo "GitHub API failed to validate k3s version ${{ inputs.k3sVersion }} (HTTP $http_code after $max_attempts attempts)"
+              echo "This may be a temporary GitHub API issue - consider re-running the workflow"
+            fi
+            exit 1
+          fi
+          echo "Attempt $attempt/$max_attempts failed (HTTP $http_code), retrying in $delay seconds..."
+          sleep $delay
+          delay=$((delay * 2))
+          attempt=$((attempt + 1))
+        done
+
+    - name: Validate k3s control plane node count
+      if: ${{ inputs.clusterProvider == 'k3s' }}
+      shell: bash
+      run: |
+        if [[ "${{ inputs.numControlPlaneNodes }}" -gt 1 ]]; then
+          echo "k3s provider currently supports only 1 control plane node (got: ${{ inputs.numControlPlaneNodes }})"
+          echo "Multi-control-plane requires embedded etcd and is not yet implemented"
+          exit 1
+        fi
 
     - name: Validate Calico version input
       shell: bash
@@ -619,6 +671,32 @@ runs:
           exit 1
         fi
 
+    # Cache k3s binary to avoid download failures during outages
+    - name: Cache k3s binary
+      if: ${{ inputs.clusterProvider == 'k3s' }}
+      id: cache-k3s
+      uses: actions/cache@v5
+      with:
+        path: /tmp/k3s-binary
+        key: k3s-${{ inputs.k3sVersion }}-${{ runner.os }}-${{ runner.arch }}
+
+    # Install k3s binary (Linux only)
+    - name: Install k3s
+      if: ${{ inputs.clusterProvider == 'k3s' }}
+      shell: bash
+      run: |
+        OS=$(echo "${{ runner.os }}" | tr '[:upper:]' '[:lower:]')
+        ${{ github.action_path }}/scripts/install-k3s.sh "${{ inputs.k3sVersion }}" "$OS" ${{ runner.arch }}
+
+    - name: Add error handling for k3s installation
+      if: ${{ inputs.clusterProvider == 'k3s' }}
+      shell: bash
+      run: |
+        if ! command -v k3s &> /dev/null; then
+          echo "k3s installation failed. Exiting."
+          exit 1
+        fi
+
     # Create a new Kubernetes cluster using KinD
     - name: Populate temporary config file for KinD (auto-generated)
       if: ${{ inputs.clusterProvider == 'kind' && inputs.kindConfigPath == '' }}
@@ -663,6 +741,22 @@ runs:
           "${{ inputs.apiServerPort }}" \
           "${{ inputs.numControlPlaneNodes }}" \
           "${{ inputs.numWorkerNodes }}"
+
+    - name: Create a new Kubernetes cluster using k3s
+      if: ${{ inputs.clusterProvider == 'k3s' }}
+      shell: bash
+      run: |
+        REGISTRY_PORT=""
+        if [ "${{ inputs.installLocalRegistry }}" = "true" ]; then
+          REGISTRY_PORT="${{ inputs.localRegistryPort }}"
+        fi
+        ${{ github.action_path }}/scripts/start-k3s.sh \
+          "${{ inputs.disableDefaultCni }}" \
+          "${{ inputs.apiServerPort }}" \
+          "${{ inputs.numControlPlaneNodes }}" \
+          "${{ inputs.numWorkerNodes }}" \
+          "${{ inputs.clusterName }}" \
+          "$REGISTRY_PORT"
 
     # - name: Bootstrap the runner with kubectl and oc clients
     - name: Bootstrap the runner with kubectl and oc clients
@@ -738,7 +832,11 @@ runs:
       if: ${{ inputs.removeDefaultStorageClass == 'true' }}
       shell: bash
       run: |
-        oc delete storageclass standard --ignore-not-found
+        if [ "${{ inputs.clusterProvider }}" = "k3s" ]; then
+          oc delete storageclass local-path --ignore-not-found
+        else
+          oc delete storageclass standard --ignore-not-found
+        fi
 
     - name: Remove the control plane taint
       if: ${{ inputs.removeControlPlaneTaint == 'true' }}

--- a/scripts/get-latest-k3s-version.sh
+++ b/scripts/get-latest-k3s-version.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fetches the latest k3s release version from GitHub API with retries.
+# Outputs the version to stdout on success, exits non-zero on failure.
+
+RETRIES=3
+DELAY=5
+
+for ((i=1; i<=RETRIES; i++)); do
+  echo "Attempt $i to fetch k3s version..." >&2
+
+  if response=$(curl -s --max-time 30 https://api.github.com/repos/k3s-io/k3s/releases/latest) && [ -n "$response" ]; then
+    version=$(echo "$response" | jq -r '.tag_name // empty')
+
+    if [ -n "$version" ] && [ "$version" != "null" ] && [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+\+k3s[0-9]+$ ]]; then
+      echo "Successfully fetched k3s version: $version" >&2
+      echo "$version"
+      exit 0
+    else
+      echo "Invalid version format: '$version'" >&2
+    fi
+  else
+    echo "API call failed or returned empty response" >&2
+  fi
+
+  if [ $i -lt $RETRIES ]; then
+    echo "Retrying in $DELAY seconds..." >&2
+    sleep $DELAY
+  fi
+done
+
+echo "Failed to fetch valid k3s version after $RETRIES attempts" >&2
+exit 1

--- a/scripts/install-ingress-nginx.sh
+++ b/scripts/install-ingress-nginx.sh
@@ -14,9 +14,11 @@ for cmd in curl kubectl; do
   fi
 done
 
-# Use provider-specific manifest for KinD, generic for others
+# Use provider-specific manifest
 if [ "$CLUSTER_PROVIDER" = "kind" ]; then
   MANIFEST_URL="https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-${INGRESS_NGINX_VERSION}/deploy/static/provider/kind/deploy.yaml"
+elif [ "$CLUSTER_PROVIDER" = "k3s" ]; then
+  MANIFEST_URL="https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-${INGRESS_NGINX_VERSION}/deploy/static/provider/baremetal/deploy.yaml"
 else
   MANIFEST_URL="https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-${INGRESS_NGINX_VERSION}/deploy/static/provider/cloud/deploy.yaml"
 fi

--- a/scripts/install-k3s.sh
+++ b/scripts/install-k3s.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: install-k3s.sh <version> <os> <arch>
+
+VERSION="${1:-}"
+OS="${2:-}"
+ARCH="${3:-}"
+
+if [ -z "$VERSION" ] || [ -z "$OS" ] || [ -z "$ARCH" ]; then
+  echo "Usage: $0 <version> <os> <arch>"
+  echo "Example: $0 v1.35.3+k3s1 linux amd64"
+  exit 1
+fi
+
+OS=$(echo "$OS" | tr '[:upper:]' '[:lower:]')
+ARCH=$(echo "$ARCH" | tr '[:upper:]' '[:lower:]')
+
+if [ "$OS" != "linux" ]; then
+  echo "❌ k3s is only supported on Linux (got: $OS)"
+  echo "   Use 'kind' or 'minikube' for macOS"
+  exit 1
+fi
+
+if [ "$ARCH" = "x64" ]; then
+  ARCH="amd64"
+fi
+
+# k3s binary is 'k3s' for amd64, 'k3s-arm64' for arm64
+BINARY_NAME="k3s"
+if [ "$ARCH" = "arm64" ]; then
+  BINARY_NAME="k3s-arm64"
+fi
+
+echo "Installing k3s ${VERSION} for linux/${ARCH}..."
+
+if [ -f /tmp/k3s-binary ]; then
+  echo "✅ Using cached k3s binary"
+  sudo cp /tmp/k3s-binary /usr/local/bin/k3s
+  sudo chmod +x /usr/local/bin/k3s
+  exit 0
+fi
+
+# + must be URL-encoded as %2B in GitHub releases URLs
+ENCODED_VERSION="${VERSION//+/%2B}"
+
+DOWNLOAD_URL="https://github.com/k3s-io/k3s/releases/download/${ENCODED_VERSION}/${BINARY_NAME}"
+
+echo "Downloading k3s ${VERSION} for linux/${ARCH}..."
+echo "📥 Attempting download from: ${DOWNLOAD_URL}"
+
+if ! curl -fsSL -o k3s "${DOWNLOAD_URL}"; then
+  echo "❌ Failed to download k3s binary"
+  echo ""
+  echo "Attempted URL: ${DOWNLOAD_URL}"
+  echo ""
+  echo "This may be due to:"
+  echo "  1. Network connectivity issues"
+  echo "  2. GitHub releases outage"
+  echo "  3. Invalid version: ${VERSION}"
+  echo "  4. Unsupported architecture: ${ARCH}"
+  echo ""
+  echo "💡 Tip: Try re-running the workflow later"
+  echo "        The binary will be cached for future runs once successfully downloaded"
+  exit 1
+fi
+
+if file k3s | grep -q "HTML"; then
+  echo "❌ Downloaded file is HTML, not a binary"
+  echo "   This usually means the version or URL is incorrect"
+  rm -f k3s
+  exit 1
+fi
+
+echo "✅ Successfully downloaded k3s binary"
+
+chmod +x k3s
+cp k3s /tmp/k3s-binary
+sudo mv k3s /usr/local/bin/
+
+echo "✅ k3s ${VERSION} installed successfully"

--- a/scripts/setup-local-registry.sh
+++ b/scripts/setup-local-registry.sh
@@ -43,16 +43,15 @@ while [ $attempt -le $max_attempts ]; do
   attempt=$((attempt + 1))
 done
 
+# Provider-specific network configuration
 if [ "${CLUSTER_PROVIDER}" = "kind" ]; then
-  # Connect registry to the KinD network
   echo "Connecting registry to KinD network..."
   docker network connect "${CLUSTER_NAME}" "${REGISTRY_NAME}" 2>/dev/null || true
+fi
 
-  # Document the local registry for KinD
-  # See: https://kind.sigs.k8s.io/docs/user/local-registry/
-  echo "Configuring KinD to use local registry..."
-
-  cat <<EOF | kubectl apply -f -
+# Create ConfigMap for registry discoverability (all providers)
+echo "Configuring ${CLUSTER_PROVIDER} to use local registry..."
+cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -63,25 +62,6 @@ data:
     host: "localhost:${REGISTRY_PORT}"
     help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
 EOF
-fi
-
-if [ "${CLUSTER_PROVIDER}" = "minikube" ]; then
-  echo "Configuring Minikube to use local registry..."
-
-  # For Minikube, we need to configure the registry as an insecure registry
-  # This is typically done at minikube start, but we can add the ConfigMap for documentation
-  cat <<EOF | kubectl apply -f -
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: local-registry-hosting
-  namespace: kube-public
-data:
-  localRegistryHosting.v1: |
-    host: "localhost:${REGISTRY_PORT}"
-    help: "Local registry for quick-k8s"
-EOF
-fi
 
 echo ""
 echo "=============================================="

--- a/scripts/start-k3s.sh
+++ b/scripts/start-k3s.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: start-k3s.sh <disable_cni> <api_port> <num_control_plane> <num_workers> <cluster_name> [registry_port]
+
+DISABLE_CNI="${1:-false}"
+API_PORT="${2:-6443}"
+# $3 (num_control_plane) is validated in action.yml; must be 1
+NUM_WORKERS="${4:-0}"
+CLUSTER_NAME="${5:-k3s}"
+REGISTRY_PORT="${6:-}"
+
+sudo mkdir -p /etc/rancher/k3s
+
+if [ -n "$REGISTRY_PORT" ]; then
+  echo "Configuring k3s registry mirror for localhost:${REGISTRY_PORT}..."
+  sudo tee /etc/rancher/k3s/registries.yaml > /dev/null <<EOF
+mirrors:
+  "localhost:${REGISTRY_PORT}":
+    endpoint:
+      - "http://localhost:${REGISTRY_PORT}"
+EOF
+fi
+
+K3S_ARGS=(
+  server
+  "--write-kubeconfig-mode=644"
+  "--disable=traefik,servicelb"
+  "--node-name=${CLUSTER_NAME}-control-plane"
+  "--https-listen-port=${API_PORT}"
+  "--tls-san=127.0.0.1"
+  "--tls-san=0.0.0.0"
+)
+
+if [ "$DISABLE_CNI" = "true" ]; then
+  echo "⚠️  k3s: Disabling built-in Flannel CNI"
+  K3S_ARGS+=("--flannel-backend=none" "--disable-network-policy")
+
+  # k3s skips CNI plugin binaries when Flannel is disabled, but the base
+  # plugins (bridge, loopback, etc.) are still needed by any replacement CNI
+  if [ ! -f /opt/cni/bin/bridge ]; then
+    echo "Installing CNI plugins (required for replacement CNI)..."
+    CNI_VERSION="v1.6.2"
+    ARCH=$(uname -m)
+    if [ "$ARCH" = "x86_64" ]; then ARCH="amd64"; elif [ "$ARCH" = "aarch64" ]; then ARCH="arm64"; fi
+    sudo mkdir -p /opt/cni/bin
+    curl -fsSL "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-${ARCH}-${CNI_VERSION}.tgz" | sudo tar -xz -C /opt/cni/bin
+    echo "✅ CNI plugins installed"
+  fi
+
+  # Remove any default CNI configs that conflict with the replacement CNI
+  sudo rm -f /etc/cni/net.d/*.conflist /etc/cni/net.d/*.conf 2>/dev/null || true
+fi
+
+echo "Starting k3s server with command: sudo k3s ${K3S_ARGS[*]}"
+sudo k3s "${K3S_ARGS[@]}" &
+K3S_PID=$!
+
+echo "Waiting for k3s to be ready..."
+max_attempts=60
+attempt=1
+while [ $attempt -le $max_attempts ]; do
+  if [ -f /etc/rancher/k3s/k3s.yaml ] && sudo k3s kubectl get nodes >/dev/null 2>&1; then
+    echo "✅ k3s server is ready"
+    break
+  fi
+  if [ $attempt -eq $max_attempts ]; then
+    echo "❌ k3s failed to start after ${max_attempts} attempts"
+    echo "Checking k3s process status..."
+    if ! kill -0 "$K3S_PID" 2>/dev/null; then
+      echo "k3s process has exited unexpectedly"
+    fi
+    exit 1
+  fi
+  sleep 2
+  attempt=$((attempt + 1))
+done
+
+mkdir -p ~/.kube
+sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
+sudo chown "$(id -u):$(id -g)" ~/.kube/config
+
+if [ "$API_PORT" != "6443" ]; then
+  sed -i "s|https://127.0.0.1:6443|https://127.0.0.1:${API_PORT}|g" ~/.kube/config
+fi
+
+echo "✅ Kubeconfig configured at ~/.kube/config"
+
+echo "Waiting for control plane node to register..."
+register_attempts=60
+register_attempt=1
+while [ $register_attempt -le $register_attempts ]; do
+  if sudo k3s kubectl get node "${CLUSTER_NAME}-control-plane" >/dev/null 2>&1; then
+    break
+  fi
+  if [ $register_attempt -eq $register_attempts ]; then
+    echo "❌ Control plane node failed to register after ${register_attempts} attempts"
+    exit 1
+  fi
+  sleep 2
+  register_attempt=$((register_attempt + 1))
+done
+
+# Without CNI, nodes stay NotReady until one is installed (e.g. Calico).
+# Remove the not-ready taint so Calico DaemonSet pods can schedule.
+if [ "$DISABLE_CNI" = "true" ]; then
+  echo "⚠️  CNI disabled — removing not-ready taint so CNI pods can schedule"
+  sudo k3s kubectl taint nodes "${CLUSTER_NAME}-control-plane" node.kubernetes.io/not-ready:NoSchedule- 2>/dev/null || true
+  sudo k3s kubectl taint nodes "${CLUSTER_NAME}-control-plane" node.kubernetes.io/not-ready:NoExecute- 2>/dev/null || true
+  sudo k3s kubectl get nodes
+else
+  echo "Waiting for control plane node to be Ready..."
+  sudo k3s kubectl wait --for=condition=Ready node/"${CLUSTER_NAME}-control-plane" --timeout=120s
+fi
+
+if [ "$NUM_WORKERS" -gt 0 ]; then
+  echo "Starting ${NUM_WORKERS} worker node(s)..."
+
+  token_attempts=90
+  token_attempt=1
+  while [ $token_attempt -le $token_attempts ]; do
+    if sudo test -f /var/lib/rancher/k3s/server/token; then
+      break
+    fi
+    if [ $token_attempt -eq $token_attempts ]; then
+      echo "❌ Node token not available after ${token_attempts} attempts"
+      exit 1
+    fi
+    sleep 1
+    token_attempt=$((token_attempt + 1))
+  done
+
+  NODE_TOKEN=$(sudo cat /var/lib/rancher/k3s/server/token)
+
+  # Start all agents in parallel
+  for i in $(seq 1 "$NUM_WORKERS"); do
+    WORKER_NAME="${CLUSTER_NAME}-worker-${i}"
+    WORKER_DATA_DIR="/var/lib/rancher/k3s-agent-${i}"
+
+    # Each agent on the same machine needs unique ports to avoid conflicts
+    LB_PORT=$((6444 + i))
+    KUBELET_PORT=$((10250 + i))
+
+    echo "Starting worker node: ${WORKER_NAME}..."
+    sudo k3s agent \
+      --server="https://127.0.0.1:${API_PORT}" \
+      --token="$NODE_TOKEN" \
+      --node-name="$WORKER_NAME" \
+      --data-dir="$WORKER_DATA_DIR" \
+      --lb-server-port="$LB_PORT" \
+      --kubelet-arg="--port=${KUBELET_PORT}" &
+  done
+
+  # Wait for all workers to register
+  for i in $(seq 1 "$NUM_WORKERS"); do
+    WORKER_NAME="${CLUSTER_NAME}-worker-${i}"
+    echo "Waiting for ${WORKER_NAME} to register..."
+    register_attempts=60
+    register_attempt=1
+    while [ $register_attempt -le $register_attempts ]; do
+      if sudo k3s kubectl get node "$WORKER_NAME" >/dev/null 2>&1; then
+        if [ "$DISABLE_CNI" = "true" ]; then
+          sudo k3s kubectl taint nodes "$WORKER_NAME" node.kubernetes.io/not-ready:NoSchedule- 2>/dev/null || true
+          sudo k3s kubectl taint nodes "$WORKER_NAME" node.kubernetes.io/not-ready:NoExecute- 2>/dev/null || true
+        else
+          sudo k3s kubectl wait --for=condition=Ready "node/$WORKER_NAME" --timeout=120s
+        fi
+        break
+      fi
+      if [ $register_attempt -eq $register_attempts ]; then
+        echo "❌ Worker ${WORKER_NAME} failed to register after ${register_attempts} attempts"
+        exit 1
+      fi
+      sleep 2
+      register_attempt=$((register_attempt + 1))
+    done
+    echo "✅ Worker node ${WORKER_NAME} registered"
+  done
+fi
+
+echo ""
+echo "✅ k3s cluster started successfully"
+sudo k3s kubectl get nodes


### PR DESCRIPTION
## Summary

- Add k3s as a third `clusterProvider` option alongside KinD and Minikube
- k3s is a lightweight, CNCF-certified Kubernetes distribution (~60MB binary, ~512MB RAM, sub-30s startup)
- Follows the exact patterns established by KinD and Minikube providers

## Changes

**New files:**
- `scripts/install-k3s.sh` — Binary download with caching, URL-encoded version handling
- `scripts/start-k3s.sh` — Server/agent process management with parallel worker node startup
- `.github/workflows/k3s-update.yml` — Nightly version update workflow (4 AM UTC)

**Modified files:**
- `action.yml` — New `k3sVersion` input, validation, cache/install/create steps, storage class fix
- `scripts/setup-local-registry.sh` — Consolidated ConfigMap into single block for all providers
- `scripts/install-ingress-nginx.sh` — k3s uses `baremetal` provider manifest
- `.github/workflows/pre-main.yml` — k3s added to provider matrix (12 Linux combos)
- `.github/workflows/nightly.yml` — k3s added to all test matrices

**Key design decisions:**
- Direct binary download (not k3s install script) for consistency
- Built-in Traefik/ServiceLB disabled by default to avoid conflicts
- Single control plane only (multi-CP requires embedded etcd)
- Linux-only (k3s has no macOS binary)
- Worker nodes start in parallel for faster multi-node setup

## Test plan

- [x] `make lint` passes (shellcheck on all scripts)
- [x] Basic k3s cluster creation works across all 4 Ubuntu variants
- [x] k3s with `disableDefaultCni: true` + Calico installation works
- [x] k3s with `installOLM: true` works
- [x] k3s with `installLocalRegistry: true` works
- [x] k3s with `installIngressNginx: true` works (baremetal manifest)
- [x] Multi-node k3s (1 CP + workers) works
- [x] KinD and Minikube tests are unaffected (no regressions)

Closes #110