### PR TITLE
Fix k3s nightly failures by using built-in Flannel CNI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,6 +29,7 @@ jobs:
         uses: ./
         with:
           clusterProvider: ${{ matrix.provider }}
+          disableDefaultCni: ${{ matrix.provider != 'k3s' }}
           waitForPodsReady: true
 
       - name: Verify cluster is operational
@@ -62,6 +63,7 @@ jobs:
           clusterProvider: ${{ matrix.provider }}
           numControlPlaneNodes: ${{ matrix.nodes.controlPlane }}
           numWorkerNodes: ${{ matrix.nodes.workers }}
+          disableDefaultCni: ${{ matrix.provider != 'k3s' }}
           waitForPodsReady: true
 
       - name: Verify node count
@@ -93,6 +95,7 @@ jobs:
         with:
           clusterProvider: ${{ matrix.provider }}
           installOLM: true
+          disableDefaultCni: ${{ matrix.provider != 'k3s' }}
           waitForPodsReady: true
 
       - name: Verify OLM installation
@@ -132,6 +135,7 @@ jobs:
           clusterProvider: ${{ matrix.provider }}
           installIstio: true
           istioProfile: ${{ matrix.istio-profile }}
+          disableDefaultCni: ${{ matrix.provider != 'k3s' }}
           waitForPodsReady: true
 
       - name: Verify Istio installation
@@ -165,6 +169,7 @@ jobs:
           istioProfile: minimal
           removeDefaultStorageClass: true
           removeControlPlaneTaint: true
+          disableDefaultCni: ${{ matrix.provider != 'k3s' }}
           waitForPodsReady: true
 
       - name: Verify all features


### PR DESCRIPTION
## Summary

- All k3s nightly jobs (14/14 per run) have failed every night since k3s was added on April 14, causing 7 consecutive red nightly runs
- Root cause: nightly workflow did not set disableDefaultCni, so k3s defaulted to true — disabling built-in Flannel and attempting to install Calico, a configuration that was never validated
- Fix: set disableDefaultCni to false for k3s in all nightly jobs, matching what pre-main.yml already does successfully

## Test plan

- [ ] CI passes on this PR (pre-main tests include k3s with this same config)
- [ ] Next nightly run passes all k3s jobs