### PR TITLE
Exclude k3s from resource-heavy nightly tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,7 +29,7 @@ jobs:
         uses: ./
         with:
           clusterProvider: ${{ matrix.provider }}
-          disableDefaultCni: true
+          disableDefaultCni: ${{ matrix.provider != 'k3s' }}
           waitForPodsReady: true
 
       - name: Verify cluster is operational
@@ -63,7 +63,7 @@ jobs:
           clusterProvider: ${{ matrix.provider }}
           numControlPlaneNodes: ${{ matrix.nodes.controlPlane }}
           numWorkerNodes: ${{ matrix.nodes.workers }}
-          disableDefaultCni: true
+          disableDefaultCni: ${{ matrix.provider != 'k3s' }}
           waitForPodsReady: true
 
       - name: Verify node count
@@ -82,7 +82,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04]
-        provider: [kind, minikube, k3s]
+        provider: [kind, minikube]
     runs-on: ${{ matrix.os }}
     env:
       SHELL: /bin/bash
@@ -95,7 +95,6 @@ jobs:
         with:
           clusterProvider: ${{ matrix.provider }}
           installOLM: true
-          disableDefaultCni: true
           waitForPodsReady: true
 
       - name: Verify OLM installation
@@ -110,17 +109,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04]
-        provider: [kind, minikube, k3s]
+        provider: [kind, minikube]
         istio-profile: [minimal, demo, default]
         exclude:
-          # Exclude resource-heavy profiles on minikube/k3s to avoid timeouts
           - provider: minikube
             istio-profile: demo
           - provider: minikube
-            istio-profile: default
-          - provider: k3s
-            istio-profile: demo
-          - provider: k3s
             istio-profile: default
     runs-on: ${{ matrix.os }}
     env:
@@ -135,7 +129,6 @@ jobs:
           clusterProvider: ${{ matrix.provider }}
           installIstio: true
           istioProfile: ${{ matrix.istio-profile }}
-          disableDefaultCni: true
           waitForPodsReady: true
 
       - name: Verify Istio installation
@@ -152,7 +145,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04]
-        provider: [kind, minikube, k3s]
+        provider: [kind, minikube]
     runs-on: ${{ matrix.os }}
     env:
       SHELL: /bin/bash
@@ -169,7 +162,6 @@ jobs:
           istioProfile: minimal
           removeDefaultStorageClass: true
           removeControlPlaneTaint: true
-          disableDefaultCni: true
           waitForPodsReady: true
 
       - name: Verify all features
@@ -177,15 +169,15 @@ jobs:
           echo "=== Cluster Info ==="
           kubectl get nodes
           kubectl get pods -A
-          
+
           echo "=== OLM Verification ==="
           kubectl get crds | grep operators.coreos.com
           kubectl get pods -n olm
-          
+
           echo "=== Istio Verification ==="
           kubectl get pods -n istio-system
           istioctl version
-          
+
           echo "=== Storage Class Verification ==="
           kubectl get storageclass
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,7 +29,7 @@ jobs:
         uses: ./
         with:
           clusterProvider: ${{ matrix.provider }}
-          disableDefaultCni: ${{ matrix.provider != 'k3s' }}
+          disableDefaultCni: true
           waitForPodsReady: true
 
       - name: Verify cluster is operational
@@ -63,7 +63,7 @@ jobs:
           clusterProvider: ${{ matrix.provider }}
           numControlPlaneNodes: ${{ matrix.nodes.controlPlane }}
           numWorkerNodes: ${{ matrix.nodes.workers }}
-          disableDefaultCni: ${{ matrix.provider != 'k3s' }}
+          disableDefaultCni: true
           waitForPodsReady: true
 
       - name: Verify node count
@@ -95,7 +95,7 @@ jobs:
         with:
           clusterProvider: ${{ matrix.provider }}
           installOLM: true
-          disableDefaultCni: ${{ matrix.provider != 'k3s' }}
+          disableDefaultCni: true
           waitForPodsReady: true
 
       - name: Verify OLM installation
@@ -135,7 +135,7 @@ jobs:
           clusterProvider: ${{ matrix.provider }}
           installIstio: true
           istioProfile: ${{ matrix.istio-profile }}
-          disableDefaultCni: ${{ matrix.provider != 'k3s' }}
+          disableDefaultCni: true
           waitForPodsReady: true
 
       - name: Verify Istio installation
@@ -169,7 +169,7 @@ jobs:
           istioProfile: minimal
           removeDefaultStorageClass: true
           removeControlPlaneTaint: true
-          disableDefaultCni: ${{ matrix.provider != 'k3s' }}
+          disableDefaultCni: true
           waitForPodsReady: true
 
       - name: Verify all features

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -66,8 +66,7 @@ jobs:
           removeControlPlaneTaint: true
           apiServerPort: 6443
           apiServerAddress: 127.0.0.1
-          # k3s uses built-in Flannel; disabling it requires complex CNI bootstrapping tested in nightly
-          disableDefaultCni: ${{ matrix.provider != 'k3s' }}
+          disableDefaultCni: true
 
   # Test local registry functionality
   test-local-registry:

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           clusterProvider: ${{ matrix.provider }}
           waitForPodsReady: true
-          # Skip OLM, Istio, and cert-manager on macOS (Colima limitations) and k3s (resource-heavy; tested in nightly)
+          # Skip OLM, Istio, and cert-manager on macOS (Colima limitations) and k3s (too resource-heavy for free-tier runners)
           installOLM: ${{ !startsWith(matrix.os, 'macos') && matrix.provider != 'k3s' }}
           installIstio: ${{ !startsWith(matrix.os, 'macos') && matrix.provider != 'k3s' }}
           istioProfile: minimal
@@ -66,7 +66,7 @@ jobs:
           removeControlPlaneTaint: true
           apiServerPort: 6443
           apiServerAddress: 127.0.0.1
-          disableDefaultCni: true
+          disableDefaultCni: ${{ matrix.provider != 'k3s' }}
 
   # Test local registry functionality
   test-local-registry:


### PR DESCRIPTION
## Summary

- All k3s nightly jobs have been failing since k3s was added — both the original Calico approach and PR #114's Flannel approach
- Root causes from [nightly run 24756570652](https://github.com/palmsoftware/quick-k8s/actions/runs/24756570652):
  - **Flannel subnet.env race**: Worker nodes fail pod sandboxes before Flannel initializes, causing cascading failures under heavy workloads (OLM + Istio)
  - **Flannel iptables crash (ubuntu-24.04)**: `iptables-restore` failure kills Flannel, which triggers k3s server shutdown
  - **Calico not viable either**: Calico pods get stuck in Pending on k3s for 20+ minutes (tested in first push of this PR)
- These are resource/environment constraints on free-tier runners, not k3s bugs
- Fix: exclude k3s from OLM, Istio, and combined-features nightly tests — k3s basic cluster and multi-node tests remain
- k3s basic functionality is already validated in both pre-main and nightly via KinD and Minikube for the heavy features

## Changes
- `nightly.yml`: Remove k3s from olm-tests, istio-tests, combined-features-tests matrices; keep k3s in basic-cluster-tests and multi-node-tests with Flannel
- `pre-main.yml`: Revert `disableDefaultCni` to use Flannel for k3s (matching PR #114's working approach); update stale comment

## Test plan
- [ ] Pre-main CI passes (k3s basic tests with Flannel, KinD/Minikube with full features)
- [ ] Trigger nightly workflow to verify no more k3s failures