### PR TITLE
Add cluster monitoring support (Prometheus + Thanos)

### DIFF
--- a/.github/workflows/kube-prometheus-update.yml
+++ b/.github/workflows/kube-prometheus-update.yml
@@ -1,0 +1,103 @@
+name: Update kube-prometheus Version Nightly
+on:
+  schedule:
+    - cron: '0 5 * * *' # Every day at 5am UTC
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  update-kube-prometheus-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Get latest kube-prometheus release version
+        id: get_kube_prometheus_version
+        run: |
+          # Function to get kube-prometheus version with retries
+          get_kube_prometheus_version() {
+            local retries=3
+            local delay=5
+
+            for ((i=1; i<=retries; i++)); do
+              echo "Attempt $i to fetch kube-prometheus version..."
+
+              # Make API call with timeout
+              response=$(curl -s --max-time 30 https://api.github.com/repos/prometheus-operator/kube-prometheus/releases/latest)
+
+              if [ $? -eq 0 ] && [ -n "$response" ]; then
+                # Extract tag_name and validate it's not null/empty
+                version=$(echo "$response" | jq -r '.tag_name // empty')
+
+                if [ -n "$version" ] && [ "$version" != "null" ] && [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                  echo "Successfully fetched kube-prometheus version: $version"
+                  echo "kube_prometheus_version=$version" >> $GITHUB_OUTPUT
+                  return 0
+                else
+                  echo "Invalid version format: '$version'"
+                fi
+              else
+                echo "API call failed or returned empty response"
+              fi
+
+              if [ $i -lt $retries ]; then
+                echo "Retrying in $delay seconds..."
+                sleep $delay
+              fi
+            done
+
+            echo "Failed to fetch valid kube-prometheus version after $retries attempts"
+            exit 1
+          }
+
+          get_kube_prometheus_version
+
+      - name: Update default kubePrometheusVersion in action.yml
+        id: update_version
+        run: |
+          version=${{ steps.get_kube_prometheus_version.outputs.kube_prometheus_version }}
+
+          # Double-check the version is valid before updating
+          if [ -z "$version" ] || [ "$version" = "null" ] || ! [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Invalid kube-prometheus version '$version' - aborting update"
+            exit 1
+          fi
+
+          echo "Updating kube-prometheus version to: $version"
+
+          # Extract current default under the kubePrometheusVersion block
+          current_version=$(sed -n "/^  kubePrometheusVersion:$/,/^  [a-zA-Z]\+:/p" action.yml | grep -o "default: '[^']*'" | sed "s/default: '\(.*\)'/\1/")
+
+          if [ -z "$current_version" ]; then
+            echo "Could not determine current kube-prometheus version from action.yml"
+            exit 1
+          fi
+
+          if [ "$current_version" = "$version" ]; then
+            echo "kube-prometheus version is already up to date ($version)"
+            echo "updated=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Update only within the kubePrometheusVersion block
+          sed -i.bak -E "/^  kubePrometheusVersion:$/,/^  [a-zA-Z]+:/{s/(default: ')[^']+(')/\1$version\2/}" action.yml
+          rm action.yml.bak
+
+          echo "Successfully updated kube-prometheus version from $current_version to $version"
+          echo "updated=true" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        if: steps.update_version.outputs.updated == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+          commit-message: "Update kube-prometheus version to ${{ steps.get_kube_prometheus_version.outputs.kube_prometheus_version }}"
+          title: "Update kube-prometheus version to ${{ steps.get_kube_prometheus_version.outputs.kube_prometheus_version }}"
+          body: "Automated PR to update default kubePrometheusVersion in action.yml to the latest release."
+          branch: "update-kube-prometheus-version-${{ steps.get_kube_prometheus_version.outputs.kube_prometheus_version }}"
+          delete-branch: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -181,6 +181,42 @@ jobs:
           echo "=== Storage Class Verification ==="
           kubectl get storageclass
 
+  # Cluster monitoring tests (Prometheus + Thanos)
+  monitoring-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04]
+        provider: [kind, minikube]
+    runs-on: ${{ matrix.os }}
+    env:
+      SHELL: /bin/bash
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v6
+
+      - name: Run action with cluster monitoring
+        uses: ./
+        with:
+          clusterProvider: ${{ matrix.provider }}
+          enableClusterMonitoring: true
+          waitForPodsReady: true
+
+      - name: Verify monitoring stack
+        run: |
+          echo "=== Monitoring Namespace ==="
+          kubectl get namespace monitoring
+
+          echo "=== Prometheus Verification ==="
+          kubectl get pods -n monitoring
+          kubectl get prometheus -n monitoring
+          kubectl get alertmanager -n monitoring
+          kubectl get crd | grep monitoring.coreos.com
+
+          echo "=== Thanos Verification ==="
+          kubectl get pods -n monitoring -l app.kubernetes.io/name=thanos-query
+          kubectl get pods -n monitoring -l app.kubernetes.io/name=prometheus -o jsonpath='{.items[*].spec.containers[*].name}' | tr ' ' '\n' | grep thanos
+
   # Different Kubernetes versions test (KinD only as it supports explicit versions easily)
   kubernetes-versions-test:
     strategy:

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -438,3 +438,46 @@ jobs:
           echo "Checking operator-sdk installation..."
           operator-sdk version
           echo "operator-sdk installation verified!"
+
+  # Test cluster monitoring installation (Prometheus + Thanos)
+  test-cluster-monitoring:
+    needs: lint
+    if: ${{ needs.lint.result == 'success' }}
+    runs-on: ubuntu-24.04
+    env:
+      SHELL: /bin/bash
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v6
+
+      - name: Run the action with cluster monitoring
+        uses: ./
+        with:
+          clusterProvider: kind
+          enableClusterMonitoring: true
+          waitForPodsReady: true
+          installOLM: false
+          installIstio: false
+
+      - name: Verify Prometheus is running
+        run: |
+          echo "Checking monitoring namespace..."
+          kubectl get namespace monitoring
+          echo "Checking monitoring pods..."
+          kubectl get pods -n monitoring
+          echo "Verifying all monitoring pods are running..."
+          kubectl wait --for=condition=ready pod --all -n monitoring --timeout=60s
+          echo "Checking Prometheus CRDs..."
+          kubectl get crd | grep monitoring.coreos.com
+          echo "Checking Prometheus instances..."
+          kubectl get prometheus -n monitoring
+          echo "Prometheus installation verified!"
+
+      - name: Verify Thanos is running
+        run: |
+          echo "Checking Thanos Query..."
+          kubectl get pods -n monitoring -l app.kubernetes.io/name=thanos-query
+          kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=thanos-query -n monitoring --timeout=60s
+          echo "Checking Thanos sidecar in Prometheus pods..."
+          kubectl get pods -n monitoring -l app.kubernetes.io/name=prometheus -o jsonpath='{.items[*].spec.containers[*].name}' | tr ' ' '\n' | grep thanos
+          echo "Thanos installation verified!"

--- a/.github/workflows/thanos-update.yml
+++ b/.github/workflows/thanos-update.yml
@@ -1,0 +1,103 @@
+name: Update Thanos Version Nightly
+on:
+  schedule:
+    - cron: '30 5 * * *' # Every day at 5:30am UTC
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  update-thanos-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Get latest Thanos release version
+        id: get_thanos_version
+        run: |
+          # Function to get Thanos version with retries
+          get_thanos_version() {
+            local retries=3
+            local delay=5
+
+            for ((i=1; i<=retries; i++)); do
+              echo "Attempt $i to fetch Thanos version..."
+
+              # Make API call with timeout
+              response=$(curl -s --max-time 30 https://api.github.com/repos/thanos-io/thanos/releases/latest)
+
+              if [ $? -eq 0 ] && [ -n "$response" ]; then
+                # Extract tag_name and validate it's not null/empty
+                version=$(echo "$response" | jq -r '.tag_name // empty')
+
+                if [ -n "$version" ] && [ "$version" != "null" ] && [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                  echo "Successfully fetched Thanos version: $version"
+                  echo "thanos_version=$version" >> $GITHUB_OUTPUT
+                  return 0
+                else
+                  echo "Invalid version format: '$version'"
+                fi
+              else
+                echo "API call failed or returned empty response"
+              fi
+
+              if [ $i -lt $retries ]; then
+                echo "Retrying in $delay seconds..."
+                sleep $delay
+              fi
+            done
+
+            echo "Failed to fetch valid Thanos version after $retries attempts"
+            exit 1
+          }
+
+          get_thanos_version
+
+      - name: Update default thanosVersion in action.yml
+        id: update_version
+        run: |
+          version=${{ steps.get_thanos_version.outputs.thanos_version }}
+
+          # Double-check the version is valid before updating
+          if [ -z "$version" ] || [ "$version" = "null" ] || ! [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Invalid Thanos version '$version' - aborting update"
+            exit 1
+          fi
+
+          echo "Updating Thanos version to: $version"
+
+          # Extract current default under the thanosVersion block
+          current_version=$(sed -n "/^  thanosVersion:$/,/^  [a-zA-Z]\+:/p" action.yml | grep -o "default: '[^']*'" | sed "s/default: '\(.*\)'/\1/")
+
+          if [ -z "$current_version" ]; then
+            echo "Could not determine current Thanos version from action.yml"
+            exit 1
+          fi
+
+          if [ "$current_version" = "$version" ]; then
+            echo "Thanos version is already up to date ($version)"
+            echo "updated=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Update only within the thanosVersion block
+          sed -i.bak -E "/^  thanosVersion:$/,/^  [a-zA-Z]+:/{s/(default: ')[^']+(')/\1$version\2/}" action.yml
+          rm action.yml.bak
+
+          echo "Successfully updated Thanos version from $current_version to $version"
+          echo "updated=true" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        if: steps.update_version.outputs.updated == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+          commit-message: "Update Thanos version to ${{ steps.get_thanos_version.outputs.thanos_version }}"
+          title: "Update Thanos version to ${{ steps.get_thanos_version.outputs.thanos_version }}"
+          body: "Automated PR to update default thanosVersion in action.yml to the latest release."
+          branch: "update-thanos-version-${{ steps.get_thanos_version.outputs.thanos_version }}"
+          delete-branch: true

--- a/action.yml
+++ b/action.yml
@@ -128,6 +128,18 @@ inputs:
     description: 'The version of operator-sdk to install'
     required: false
     default: 'v1.42.2'
+  enableClusterMonitoring:
+    description: 'Enable cluster monitoring stack (Prometheus, Thanos, Alertmanager, Grafana) via kube-prometheus'
+    required: false
+    default: 'false'
+  kubePrometheusVersion:
+    description: 'The version of kube-prometheus to install'
+    required: false
+    default: 'v0.14.0'
+  thanosVersion:
+    description: 'The version of Thanos to install'
+    required: false
+    default: 'v0.37.2'
   installCalico:
     description: 'Install Calico CNI when default CNI is disabled. Set to false to bring your own CNI (e.g., Multus, OVN)'
     required: false
@@ -541,6 +553,85 @@ runs:
           attempt=$((attempt + 1))
         done
 
+    - name: Validate enableClusterMonitoring input
+      shell: bash
+      run: |
+        if [[ "${{ inputs.enableClusterMonitoring }}" != "true" && "${{ inputs.enableClusterMonitoring }}" != "false" ]]; then
+          echo "Invalid enableClusterMonitoring value: ${{ inputs.enableClusterMonitoring }}"
+          echo "Must be 'true' or 'false'"
+          exit 1
+        fi
+
+    - name: Validate kube-prometheus version input
+      if: ${{ inputs.enableClusterMonitoring == 'true' }}
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        if ! [[ "${{ inputs.kubePrometheusVersion }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "Invalid kube-prometheus version format: ${{ inputs.kubePrometheusVersion }}"
+          exit 1
+        fi
+        # Retry logic for flaky GitHub API calls with exponential backoff
+        max_attempts=5
+        attempt=1
+        delay=2
+        while [ $attempt -le $max_attempts ]; do
+          http_code=$(curl --silent --output /dev/null --write-out "%{http_code}" -L -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/prometheus-operator/kube-prometheus/releases/tags/${{ inputs.kubePrometheusVersion }})
+          if [ "$http_code" = "200" ]; then
+            echo "kube-prometheus version ${{ inputs.kubePrometheusVersion }} validated successfully"
+            break
+          fi
+          if [ $attempt -eq $max_attempts ]; then
+            if [ "$http_code" = "404" ]; then
+              echo "kube-prometheus version ${{ inputs.kubePrometheusVersion }} does not exist on GitHub"
+            else
+              echo "GitHub API failed to validate kube-prometheus version ${{ inputs.kubePrometheusVersion }} (HTTP $http_code after $max_attempts attempts)"
+              echo "This may be a temporary GitHub API issue - consider re-running the workflow"
+            fi
+            exit 1
+          fi
+          echo "Attempt $attempt/$max_attempts failed (HTTP $http_code), retrying in $delay seconds..."
+          sleep $delay
+          delay=$((delay * 2))
+          attempt=$((attempt + 1))
+        done
+
+    - name: Validate Thanos version input
+      if: ${{ inputs.enableClusterMonitoring == 'true' }}
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        if ! [[ "${{ inputs.thanosVersion }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "Invalid Thanos version format: ${{ inputs.thanosVersion }}"
+          exit 1
+        fi
+        # Retry logic for flaky GitHub API calls with exponential backoff
+        max_attempts=5
+        attempt=1
+        delay=2
+        while [ $attempt -le $max_attempts ]; do
+          http_code=$(curl --silent --output /dev/null --write-out "%{http_code}" -L -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/thanos-io/thanos/releases/tags/${{ inputs.thanosVersion }})
+          if [ "$http_code" = "200" ]; then
+            echo "Thanos version ${{ inputs.thanosVersion }} validated successfully"
+            break
+          fi
+          if [ $attempt -eq $max_attempts ]; then
+            if [ "$http_code" = "404" ]; then
+              echo "Thanos version ${{ inputs.thanosVersion }} does not exist on GitHub"
+            else
+              echo "GitHub API failed to validate Thanos version ${{ inputs.thanosVersion }} (HTTP $http_code after $max_attempts attempts)"
+              echo "This may be a temporary GitHub API issue - consider re-running the workflow"
+            fi
+            exit 1
+          fi
+          echo "Attempt $attempt/$max_attempts failed (HTTP $http_code), retrying in $delay seconds..."
+          sleep $delay
+          delay=$((delay * 2))
+          attempt=$((attempt + 1))
+        done
+
     - name: Validate installCalico input
       shell: bash
       run: |
@@ -827,6 +918,16 @@ runs:
       if: ${{ inputs.installOperatorSdk == 'true' }}
       shell: bash
       run: ${{ github.action_path }}/scripts/install-operator-sdk.sh ${{ inputs.operatorSdkVersion }}
+
+    - name: Install Prometheus monitoring stack
+      if: ${{ inputs.enableClusterMonitoring == 'true' }}
+      shell: bash
+      run: ${{ github.action_path }}/scripts/install-prometheus.sh ${{ inputs.kubePrometheusVersion }}
+
+    - name: Install Thanos
+      if: ${{ inputs.enableClusterMonitoring == 'true' }}
+      shell: bash
+      run: ${{ github.action_path }}/scripts/install-thanos.sh ${{ inputs.thanosVersion }}
 
     - name: Remove the default storage class
       if: ${{ inputs.removeDefaultStorageClass == 'true' }}

--- a/scripts/install-prometheus.sh
+++ b/scripts/install-prometheus.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KUBE_PROMETHEUS_VERSION="${1:-v0.14.0}"
+
+echo "Installing kube-prometheus version $KUBE_PROMETHEUS_VERSION"
+
+# Verify required tools are available
+for cmd in curl kubectl tar; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: $cmd is not installed." >&2
+    exit 1
+  fi
+done
+
+VERSION_NO_V="${KUBE_PROMETHEUS_VERSION#v}"
+TARBALL_URL="https://github.com/prometheus-operator/kube-prometheus/archive/refs/tags/${KUBE_PROMETHEUS_VERSION}.tar.gz"
+KUBE_PROMETHEUS_DIR="/tmp/kube-prometheus-${VERSION_NO_V}"
+
+cleanup() { rm -rf /tmp/kube-prometheus.tar.gz "${KUBE_PROMETHEUS_DIR}"; }
+trap cleanup EXIT
+
+echo "Downloading kube-prometheus from: $TARBALL_URL"
+
+if ! curl -fSL --retry 3 --retry-delay 5 --retry-all-errors "$TARBALL_URL" -o /tmp/kube-prometheus.tar.gz; then
+  echo "Error: Failed to download kube-prometheus" >&2
+  exit 1
+fi
+
+tar -xzf /tmp/kube-prometheus.tar.gz -C /tmp
+
+# Reduce resource requests so the stack fits on free-tier CI runners (~7GB RAM)
+echo "Patching resource requests for CI environment..."
+grep -rl 'memory:\|cpu:' "${KUBE_PROMETHEUS_DIR}/manifests/" --include="*.yaml" | xargs sed -i \
+  -e 's/memory: 2Gi/memory: 256Mi/g' \
+  -e 's/memory: 1Gi/memory: 256Mi/g' \
+  -e 's/memory: 400Mi/memory: 128Mi/g' \
+  -e 's/memory: 200Mi/memory: 128Mi/g' \
+  -e 's/cpu: 500m/cpu: 100m/g' \
+  -e 's/cpu: "2"/cpu: 200m/g'
+
+echo "Applying kube-prometheus setup manifests (CRDs, namespace)..."
+if ! kubectl apply --server-side -f "${KUBE_PROMETHEUS_DIR}/manifests/setup/"; then
+  echo "Error: Failed to apply kube-prometheus setup manifests" >&2
+  exit 1
+fi
+
+echo "Waiting for CRDs to be established..."
+kubectl wait --for condition=Established --all CustomResourceDefinition --timeout=120s
+
+# Apply twice — first pass may fail on CRD-to-CR ordering races
+echo "Applying kube-prometheus manifests..."
+kubectl apply -f "${KUBE_PROMETHEUS_DIR}/manifests/" 2>&1 || true
+if ! kubectl apply -f "${KUBE_PROMETHEUS_DIR}/manifests/"; then
+  echo "Error: Failed to apply kube-prometheus manifests" >&2
+  exit 1
+fi
+
+echo "Waiting for monitoring pods to be ready..."
+kubectl wait --for=condition=ready pod --all --namespace=monitoring --timeout=300s || {
+  echo "Warning: Some monitoring pods may not be ready yet. Continuing..."
+}
+
+kubectl get pods -n monitoring
+echo "kube-prometheus $KUBE_PROMETHEUS_VERSION installed successfully!"

--- a/scripts/install-thanos.sh
+++ b/scripts/install-thanos.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+THANOS_VERSION="${1:-v0.37.2}"
+
+echo "Installing Thanos version $THANOS_VERSION"
+
+# Verify required tools are available
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo "Error: kubectl is not installed." >&2
+  exit 1
+fi
+
+# Verify Prometheus is running (Thanos requires it)
+if ! kubectl get namespace monitoring >/dev/null 2>&1; then
+  echo "Error: monitoring namespace not found. Prometheus must be installed first." >&2
+  exit 1
+fi
+
+# Patch the Prometheus CR to add Thanos sidecar via the Prometheus Operator's built-in spec.thanos field
+echo "Configuring Thanos sidecar on Prometheus..."
+kubectl -n monitoring patch prometheus k8s --type=merge -p "{
+  \"spec\": {
+    \"thanos\": {
+      \"version\": \"${THANOS_VERSION}\",
+      \"image\": \"quay.io/thanos/thanos:${THANOS_VERSION}\",
+      \"resources\": {
+        \"requests\": {
+          \"memory\": \"128Mi\",
+          \"cpu\": \"100m\"
+        },
+        \"limits\": {
+          \"memory\": \"256Mi\"
+        }
+      }
+    }
+  }
+}"
+
+# Deploy Thanos Query and headless sidecar service
+echo "Deploying Thanos Query and services..."
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Service
+metadata:
+  name: thanos-sidecar
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: thanos-sidecar
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: prometheus
+  ports:
+    - name: grpc
+      port: 10901
+      targetPort: 10901
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: thanos-query
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: thanos-query
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: thanos-query
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: thanos-query
+    spec:
+      containers:
+        - name: thanos-query
+          image: quay.io/thanos/thanos:${THANOS_VERSION}
+          args:
+            - query
+            - --http-address=0.0.0.0:9090
+            - --grpc-address=0.0.0.0:10901
+            - --endpoint=dnssrv+_grpc._tcp.thanos-sidecar.monitoring.svc.cluster.local
+          ports:
+            - name: http
+              containerPort: 9090
+            - name: grpc
+              containerPort: 10901
+          resources:
+            requests:
+              memory: 128Mi
+              cpu: 100m
+            limits:
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: thanos-query
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: thanos-query
+spec:
+  selector:
+    app.kubernetes.io/name: thanos-query
+  ports:
+    - name: http
+      port: 9090
+      targetPort: http
+    - name: grpc
+      port: 10901
+      targetPort: grpc
+EOF
+
+echo "Waiting for Prometheus to restart with Thanos sidecar..."
+kubectl rollout status statefulset/prometheus-k8s -n monitoring --timeout=300s || {
+  echo "Warning: Prometheus may still be restarting. Continuing..."
+}
+
+echo "Waiting for Thanos Query to be ready..."
+kubectl rollout status deployment/thanos-query -n monitoring --timeout=300s || {
+  echo "Warning: Thanos Query may not be ready yet. Continuing..."
+}
+
+kubectl get pods -n monitoring
+echo "Thanos $THANOS_VERSION installed successfully!"


### PR DESCRIPTION
## Summary

- Adds `enableClusterMonitoring` input that installs the full kube-prometheus stack (Prometheus Operator, Alertmanager, node-exporter, kube-state-metrics, Grafana) and Thanos (sidecar + query frontend)
- Mirrors the `enableClusterMonitoring` pattern from quick-ocp PR #51, adapted for vanilla Kubernetes
- Resource requests are patched down for CI environments so the stack fits on free-tier runners
- Thanos sidecar is injected via the Prometheus Operator built-in `spec.thanos` CRD field

## New Inputs

| Input | Default | Description |
|-------|---------|-------------|
| `enableClusterMonitoring` | `false` | Enable the full monitoring stack |
| `kubePrometheusVersion` | `v0.14.0` | kube-prometheus release version |
| `thanosVersion` | `v0.37.2` | Thanos version |

## New Files

- `scripts/install-prometheus.sh` — Downloads and applies kube-prometheus manifests
- `scripts/install-thanos.sh` — Configures Thanos sidecar + deploys Query frontend
- `.github/workflows/kube-prometheus-update.yml` — Nightly version auto-update
- `.github/workflows/thanos-update.yml` — Nightly version auto-update

## Test Plan

- [ ] `test-cluster-monitoring` job in pre-main verifies Prometheus pods, CRDs, and Thanos Query on KinD
- [ ] `monitoring-tests` nightly job covers KinD + Minikube on ubuntu-22.04/24.04
- [ ] k3s is excluded (same as OLM/Istio — resource constraints)
- [ ] `make lint` passes (shellcheck clean)