### PR TITLE
Update kube-prometheus to v0.17.0 and Thanos to v0.41.0

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -461,23 +461,47 @@ jobs:
 
       - name: Verify Prometheus is running
         run: |
-          echo "Checking monitoring namespace..."
           kubectl get namespace monitoring
-          echo "Checking monitoring pods..."
           kubectl get pods -n monitoring
-          echo "Verifying all monitoring pods are running..."
-          kubectl wait --for=condition=ready pod --all -n monitoring --timeout=60s
-          echo "Checking Prometheus CRDs..."
+          echo "Waiting for core monitoring components..."
+          kubectl rollout status deployment/prometheus-operator -n monitoring --timeout=300s
+          kubectl rollout status statefulset/prometheus-k8s -n monitoring --timeout=300s
           kubectl get crd | grep monitoring.coreos.com
-          echo "Checking Prometheus instances..."
           kubectl get prometheus -n monitoring
-          echo "Prometheus installation verified!"
+
+      - name: Verify NetworkPolicies are removed
+        run: |
+          echo "Checking that kube-prometheus NetworkPolicies were removed..."
+          policies=$(kubectl get networkpolicies -n monitoring --no-headers 2>/dev/null)
+          if [ -n "$policies" ]; then
+            echo "FAIL: NetworkPolicies still present in monitoring namespace:"
+            echo "$policies"
+            exit 1
+          fi
+          echo "No NetworkPolicies found — Thanos connectivity is unblocked."
 
       - name: Verify Thanos is running
         run: |
-          echo "Checking Thanos Query..."
           kubectl get pods -n monitoring -l app.kubernetes.io/name=thanos-query
-          kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=thanos-query -n monitoring --timeout=60s
-          echo "Checking Thanos sidecar in Prometheus pods..."
+          kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=thanos-query -n monitoring --timeout=300s
           kubectl get pods -n monitoring -l app.kubernetes.io/name=prometheus -o jsonpath='{.items[*].spec.containers[*].name}' | tr ' ' '\n' | grep thanos
-          echo "Thanos installation verified!"
+
+      - name: Verify Thanos Query can reach Prometheus
+        run: |
+          THANOS_POD=$(kubectl get pods -n monitoring -l app.kubernetes.io/name=thanos-query -o jsonpath='{.items[0].metadata.name}')
+          for i in $(seq 1 12); do
+            stores=$(kubectl exec -n monitoring "$THANOS_POD" -- wget -qO- http://localhost:9090/api/v1/stores 2>/dev/null || true)
+            if echo "$stores" | grep -q "sidecar"; then
+              echo "Thanos Query discovered Prometheus sidecar store."
+              exit 0
+            fi
+            echo "Attempt $i/12: Waiting for store discovery..."
+            sleep 10
+          done
+          echo "FAIL: Thanos Query did not discover sidecar stores after 2 minutes."
+          exit 1
+
+      - name: Verify monitoring stack health
+        run: |
+          kubectl get pods -n monitoring -o wide
+          kubectl get svc -n monitoring

--- a/action.yml
+++ b/action.yml
@@ -135,11 +135,11 @@ inputs:
   kubePrometheusVersion:
     description: 'The version of kube-prometheus to install'
     required: false
-    default: 'v0.14.0'
+    default: 'v0.17.0'
   thanosVersion:
     description: 'The version of Thanos to install'
     required: false
-    default: 'v0.37.2'
+    default: 'v0.41.0'
   installCalico:
     description: 'Install Calico CNI when default CNI is disabled. Set to false to bring your own CNI (e.g., Multus, OVN)'
     required: false

--- a/scripts/install-thanos.sh
+++ b/scripts/install-thanos.sh
@@ -17,6 +17,11 @@ if ! kubectl get namespace monitoring >/dev/null 2>&1; then
   exit 1
 fi
 
+# kube-prometheus ships NetworkPolicies that block Thanos Query from reaching the
+# Prometheus sidecar gRPC port. Remove them so the monitoring stack works out of the box.
+echo "Removing kube-prometheus NetworkPolicies (they block Thanos Query -> sidecar gRPC)..."
+kubectl delete networkpolicies --all -n monitoring 2>/dev/null || true
+
 # Patch the Prometheus CR to add Thanos sidecar via the Prometheus Operator's built-in spec.thanos field
 echo "Configuring Thanos sidecar on Prometheus..."
 kubectl -n monitoring patch prometheus k8s --type=merge -p "{


### PR DESCRIPTION
## Summary
- Bump kube-prometheus from v0.14.0 to v0.17.0
- Bump Thanos from v0.37.2 to v0.41.0
- Increase monitoring test verification timeouts from 60s to 300s to accommodate longer startup times
- Remove kube-prometheus NetworkPolicies during Thanos install — they block Thanos Query from reaching the Prometheus sidecar gRPC port, forcing users to manually delete them as a workaround

## Test plan
- [ ] `test-cluster-monitoring` job passes with the new versions
- [ ] Thanos Query can reach Prometheus sidecar without manual NetworkPolicy deletion

Supersedes #118 and #119.