### PR TITLE
Fix Calico install failure on K8s < 1.31 and add retries

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -873,7 +873,37 @@ runs:
       shell: bash
       run: |
         echo "Installing Calico CNI version $CALICO_VERSION..."
-        oc apply -f https://raw.githubusercontent.com/projectcalico/calico/$CALICO_VERSION/manifests/calico.yaml;
+        CALICO_URL="https://raw.githubusercontent.com/projectcalico/calico/$CALICO_VERSION/manifests/calico.yaml"
+        max_attempts=3
+        attempt=1
+        delay=5
+        while [ $attempt -le $max_attempts ]; do
+          echo "Attempt $attempt/$max_attempts: Applying Calico manifest..."
+          output=$(oc apply -f "$CALICO_URL" 2>&1) && {
+            echo "$output"
+            echo "Calico CNI installed successfully"
+            break
+          }
+          exit_code=$?
+          echo "$output"
+          # Calico v3.32+ includes CRDs using CEL functions (e.g. isCIDR) not available
+          # in K8s < 1.31. The core CNI components still install correctly, so treat
+          # CRD validation errors as non-fatal if the calico-node daemonset exists.
+          if echo "$output" | grep -q "is invalid:.*compilation failed"; then
+            if oc get daemonset calico-node -n kube-system &>/dev/null; then
+              echo "Warning: Some Calico CRDs failed validation (likely K8s version incompatibility) but core components installed successfully"
+              break
+            fi
+          fi
+          if [ $attempt -eq $max_attempts ]; then
+            echo "Calico installation failed after $max_attempts attempts"
+            exit $exit_code
+          fi
+          echo "Retrying in $delay seconds..."
+          sleep $delay
+          delay=$((delay * 2))
+          attempt=$((attempt + 1))
+        done
       env:
         CALICO_VERSION: ${{ inputs.calicoVersion }}
 


### PR DESCRIPTION
## Summary
- Fix nightly CI failure where Calico v3.32.0 install fails on kindest/node:v1.30.0 due to a CRD using the isCIDR() CEL function (only available in K8s 1.31+)
- Tolerate CRD validation errors when core Calico components (calico-node daemonset) install successfully
- Add retry logic (3 attempts with exponential backoff) for transient network failures during manifest download

## Root Cause
Calico v3.32.0 added a clusternetworkpolicies.policy.networking.k8s.io CRD with CEL validation rules using isCIDR(). This function does not exist in K8s 1.30, causing oc apply to exit 1 even though all core CNI components are created. The kindest/node:v1.31.0 matrix entry passes because that K8s version supports isCIDR().

Failing run: https://github.com/palmsoftware/quick-k8s/actions/runs/26993481427

## Test plan
- [ ] CI passes on kindest/node:v1.30.0 (previously failing)
- [ ] CI passes on kindest/node:v1.31.0 (should continue to pass)
- [ ] Other nightly tests unaffected