### PR TITLE
Fix k3s multi-node flannel iptables race condition

### DIFF
--- a/scripts/start-k3s.sh
+++ b/scripts/start-k3s.sh
@@ -132,7 +132,9 @@ if [ "$NUM_WORKERS" -gt 0 ]; then
 
   NODE_TOKEN=$(sudo cat /var/lib/rancher/k3s/server/token)
 
-  # Start all agents in parallel
+  # Start agents with staggered delays to avoid flannel iptables race.
+  # All k3s processes share the host iptables namespace; simultaneous flannel
+  # instances race on iptables-restore when setting up masquerade rules.
   for i in $(seq 1 "$NUM_WORKERS"); do
     WORKER_NAME="${CLUSTER_NAME}-worker-${i}"
     WORKER_DATA_DIR="/var/lib/rancher/k3s-agent-${i}"
@@ -140,6 +142,11 @@ if [ "$NUM_WORKERS" -gt 0 ]; then
     # Each agent on the same machine needs unique ports to avoid conflicts
     LB_PORT=$((6444 + i))
     KUBELET_PORT=$((10250 + i))
+
+    if [ "$i" -gt 1 ]; then
+      echo "Waiting 5s before starting next agent (flannel iptables stagger)..."
+      sleep 5
+    fi
 
     echo "Starting worker node: ${WORKER_NAME}..."
     sudo k3s agent \
@@ -176,6 +183,11 @@ if [ "$NUM_WORKERS" -gt 0 ]; then
     done
     echo "✅ Worker node ${WORKER_NAME} registered"
   done
+fi
+
+if ! kill -0 "$K3S_PID" 2>/dev/null; then
+  echo "❌ k3s server process died after worker registration (likely flannel iptables race)"
+  exit 1
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
- Stagger k3s agent starts with a 5-second delay between each launch to avoid flannel iptables race condition
- Add post-registration health check to detect if k3s server died during worker setup

## Problem
When multiple k3s agents start simultaneously on the same host, their embedded flannel instances race on `iptables-restore` while setting up masquerade rules. This causes flannel to crash with `Bad rule (does a matching rule exist in that chain?)`, which brings down the k3s server. This was an intermittent failure in nightly multi-node CI tests (e.g., [run 27114566779](https://github.com/palmsoftware/quick-k8s/actions/runs/27114566779)).

## Fix
Instead of starting all agents in parallel, stagger them with a 5-second delay between each launch, giving each flannel instance time to finish iptables setup before the next one starts.

## Test plan
- [ ] `make lint` passes
- [ ] `multi-node-tests (ubuntu-24.04, k3s, 1, 2)` passes
- [ ] `multi-node-tests (ubuntu-24.04, k3s, 1, 3)` passes
- [ ] `multi-node-tests (ubuntu-22.04, k3s, 1, 2)` passes
- [ ] `multi-node-tests (ubuntu-22.04, k3s, 1, 3)` passes