### PR TITLE
Authenticate GitHub API calls in version update workflows

### DIFF
--- a/.github/workflows/calico-update.yml
+++ b/.github/workflows/calico-update.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Get latest Calico release version
         id: get_calico_version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Function to get Calico version with retries
           get_calico_version() {
@@ -28,7 +30,7 @@ jobs:
               echo "Attempt $i to fetch Calico version..."
 
               # Make API call with timeout
-              response=$(curl -s --max-time 30 https://api.github.com/repos/projectcalico/calico/releases/latest)
+              response=$(curl -s --max-time 30 -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/projectcalico/calico/releases/latest)
 
               if [ $? -eq 0 ] && [ -n "$response" ]; then
                 # Extract tag_name and validate it's not null/empty

--- a/.github/workflows/cert-manager-update.yml
+++ b/.github/workflows/cert-manager-update.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Get latest cert-manager release version
         id: get_cert_manager_version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Function to get cert-manager version with retries
           get_cert_manager_version() {
@@ -28,7 +30,7 @@ jobs:
               echo "Attempt $i to fetch cert-manager version..."
 
               # Make API call with timeout
-              response=$(curl -s --max-time 30 https://api.github.com/repos/cert-manager/cert-manager/releases/latest)
+              response=$(curl -s --max-time 30 -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/cert-manager/cert-manager/releases/latest)
 
               if [ $? -eq 0 ] && [ -n "$response" ]; then
                 # Extract tag_name and validate it's not null/empty

--- a/.github/workflows/ingress-nginx-update.yml
+++ b/.github/workflows/ingress-nginx-update.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Get latest ingress-nginx release version
         id: get_ingress_nginx_version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Function to get ingress-nginx version with retries
           get_ingress_nginx_version() {
@@ -28,7 +30,7 @@ jobs:
               echo "Attempt $i to fetch ingress-nginx version..."
 
               # Make API call with timeout
-              response=$(curl -s --max-time 30 https://api.github.com/repos/kubernetes/ingress-nginx/releases/latest)
+              response=$(curl -s --max-time 30 -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/kubernetes/ingress-nginx/releases/latest)
 
               if [ $? -eq 0 ] && [ -n "$response" ]; then
                 # Extract tag_name and validate it's not null/empty

--- a/.github/workflows/istio-update.yml
+++ b/.github/workflows/istio-update.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Get latest Istio release version
         id: get_istio_version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Function to get Istio version with retries
           get_istio_version() {
@@ -28,7 +30,7 @@ jobs:
               echo "Attempt $i to fetch Istio version..."
 
               # Make API call with timeout
-              response=$(curl -s --max-time 30 https://api.github.com/repos/istio/istio/releases/latest)
+              response=$(curl -s --max-time 30 -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/istio/istio/releases/latest)
 
               if [ $? -eq 0 ] && [ -n "$response" ]; then
                 # Extract tag_name and validate it's not null/empty

--- a/.github/workflows/kube-prometheus-update.yml
+++ b/.github/workflows/kube-prometheus-update.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Get latest kube-prometheus release version
         id: get_kube_prometheus_version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Function to get kube-prometheus version with retries
           get_kube_prometheus_version() {
@@ -28,7 +30,7 @@ jobs:
               echo "Attempt $i to fetch kube-prometheus version..."
 
               # Make API call with timeout
-              response=$(curl -s --max-time 30 https://api.github.com/repos/prometheus-operator/kube-prometheus/releases/latest)
+              response=$(curl -s --max-time 30 -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/prometheus-operator/kube-prometheus/releases/latest)
 
               if [ $? -eq 0 ] && [ -n "$response" ]; then
                 # Extract tag_name and validate it's not null/empty

--- a/.github/workflows/metrics-server-update.yml
+++ b/.github/workflows/metrics-server-update.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Get latest metrics-server release version
         id: get_metrics_server_version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Function to get metrics-server version with retries
           get_metrics_server_version() {
@@ -28,7 +30,7 @@ jobs:
               echo "Attempt $i to fetch metrics-server version..."
 
               # Make API call with timeout
-              response=$(curl -s --max-time 30 https://api.github.com/repos/kubernetes-sigs/metrics-server/releases/latest)
+              response=$(curl -s --max-time 30 -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/kubernetes-sigs/metrics-server/releases/latest)
 
               if [ $? -eq 0 ] && [ -n "$response" ]; then
                 # Extract tag_name and validate it's not null/empty

--- a/.github/workflows/minikube-update.yml
+++ b/.github/workflows/minikube-update.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Get latest Minikube release version
         id: get_minikube_version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Function to get Minikube version with retries
           get_minikube_version() {
@@ -28,7 +30,7 @@ jobs:
               echo "Attempt $i to fetch Minikube version..."
 
               # Make API call with timeout
-              response=$(curl -s --max-time 30 https://api.github.com/repos/kubernetes/minikube/releases/latest)
+              response=$(curl -s --max-time 30 -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/kubernetes/minikube/releases/latest)
 
               if [ $? -eq 0 ] && [ -n "$response" ]; then
                 # Extract tag_name and validate it's not null/empty

--- a/.github/workflows/olm-update.yml
+++ b/.github/workflows/olm-update.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Get latest OLM release version
         id: get_olm_version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Function to get OLM version with retries
           get_olm_version() {
@@ -28,7 +30,7 @@ jobs:
               echo "Attempt $i to fetch OLM version..."
               
               # Make API call with timeout
-              response=$(curl -s --max-time 30 https://api.github.com/repos/operator-framework/operator-lifecycle-manager/releases/latest)
+              response=$(curl -s --max-time 30 -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/operator-framework/operator-lifecycle-manager/releases/latest)
               
               if [ $? -eq 0 ] && [ -n "$response" ]; then
                 # Extract tag_name and validate it's not null/empty

--- a/.github/workflows/operator-sdk-update.yml
+++ b/.github/workflows/operator-sdk-update.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Get latest operator-sdk release version
         id: get_operator_sdk_version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Function to get operator-sdk version with retries
           get_operator_sdk_version() {
@@ -28,7 +30,7 @@ jobs:
               echo "Attempt $i to fetch operator-sdk version..."
 
               # Make API call with timeout
-              response=$(curl -s --max-time 30 https://api.github.com/repos/operator-framework/operator-sdk/releases/latest)
+              response=$(curl -s --max-time 30 -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/operator-framework/operator-sdk/releases/latest)
 
               if [ $? -eq 0 ] && [ -n "$response" ]; then
                 # Extract tag_name and validate it's not null/empty

--- a/.github/workflows/thanos-update.yml
+++ b/.github/workflows/thanos-update.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Get latest Thanos release version
         id: get_thanos_version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Function to get Thanos version with retries
           get_thanos_version() {
@@ -28,7 +30,7 @@ jobs:
               echo "Attempt $i to fetch Thanos version..."
 
               # Make API call with timeout
-              response=$(curl -s --max-time 30 https://api.github.com/repos/thanos-io/thanos/releases/latest)
+              response=$(curl -s --max-time 30 -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/thanos-io/thanos/releases/latest)
 
               if [ $? -eq 0 ] && [ -n "$response" ]; then
                 # Extract tag_name and validate it's not null/empty


### PR DESCRIPTION
## Summary

- All 10 nightly version update workflows were making unauthenticated GitHub API calls, limited to 60 requests/hour
- This caused transient failures when the API returned empty responses (e.g. [ingress-nginx-update run](https://github.com/palmsoftware/quick-k8s/actions/runs/27403960779))
- Added `GITHUB_TOKEN` auth headers to bump the rate limit to 5,000 requests/hour

## Affected Workflows

calico-update, cert-manager-update, ingress-nginx-update, istio-update, kube-prometheus-update, metrics-server-update, minikube-update, olm-update, operator-sdk-update, thanos-update