### PR TITLE
Remove dead envsubst check in generate-kind-config.sh

### DIFF
--- a/scripts/generate-kind-config.sh
+++ b/scripts/generate-kind-config.sh
@@ -3,11 +3,6 @@
 # Generate a KinD configuration file from parameters
 # Usage: generate-kind-config.sh <api-server-port> <api-server-address> <disable-default-cni> <ip-family> <default-node-image> <control-plane-nodes> <num-worker-nodes> <output-file> [cluster-name]
 
-if ! command -v envsubst >/dev/null 2>&1; then
-  echo "Error: envsubst is not installed." >&2
-  exit 1
-fi
-
 # Set the default values
 API_SERVER_PORT=$1
 API_SERVER_ADDRESS=$2


### PR DESCRIPTION
## Summary

- Remove unused `envsubst` availability check from `generate-kind-config.sh` — the script uses `cat` heredocs for all config generation and never calls `envsubst`

Closes #150