### PR TITLE
Add --timeout=5m to all kubectl apply commands

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Install Calico manually (simulating bring-your-own-CNI)
         run: |
           echo "Installing Calico manually to verify cluster works..."
-          kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.31.3/manifests/calico.yaml
+          kubectl apply --timeout=5m -f https://raw.githubusercontent.com/projectcalico/calico/v3.31.3/manifests/calico.yaml
           echo "Waiting for Calico pods..."
           kubectl wait --for=condition=ready pod -l k8s-app=calico-node -n kube-system --timeout=120s
           echo "Manual CNI installation successful!"
@@ -258,7 +258,7 @@ jobs:
       - name: Test cert-manager functionality with self-signed issuer
         run: |
           echo "Creating a self-signed ClusterIssuer..."
-          cat <<EOF | kubectl apply -f -
+          cat <<EOF | kubectl apply --timeout=5m -f -
           apiVersion: cert-manager.io/v1
           kind: ClusterIssuer
           metadata:

--- a/action.yml
+++ b/action.yml
@@ -884,7 +884,7 @@ runs:
         delay=5
         while [ $attempt -le $max_attempts ]; do
           echo "Attempt $attempt/$max_attempts: Applying Calico manifest..."
-          output=$(oc apply -f "$CALICO_URL" 2>&1) && {
+          output=$(oc apply --timeout=5m -f "$CALICO_URL" 2>&1) && {
             echo "$output"
             echo "Calico CNI installed successfully"
             break

--- a/scripts/install-cert-manager.sh
+++ b/scripts/install-cert-manager.sh
@@ -16,7 +16,7 @@ done
 MANIFEST_URL="https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml"
 echo "Downloading cert-manager manifest from: $MANIFEST_URL"
 
-if ! kubectl apply -f "$MANIFEST_URL"; then
+if ! kubectl apply --timeout=5m -f "$MANIFEST_URL"; then
   echo "Error: Failed to apply cert-manager manifest" >&2
   exit 1
 fi

--- a/scripts/install-ingress-nginx.sh
+++ b/scripts/install-ingress-nginx.sh
@@ -25,7 +25,7 @@ fi
 
 echo "Downloading ingress-nginx manifest from: $MANIFEST_URL"
 
-if ! kubectl apply -f "$MANIFEST_URL"; then
+if ! kubectl apply --timeout=5m -f "$MANIFEST_URL"; then
   echo "Error: Failed to apply ingress-nginx manifest" >&2
   exit 1
 fi

--- a/scripts/install-metrics-server.sh
+++ b/scripts/install-metrics-server.sh
@@ -20,7 +20,7 @@ echo "Downloading metrics-server manifest from: $MANIFEST_URL"
 # This is required for KinD/Minikube where kubelet uses self-signed certs
 if ! curl -sL "$MANIFEST_URL" | \
   sed '/args:/a\        - --kubelet-insecure-tls' | \
-  kubectl apply -f -; then
+  kubectl apply --timeout=5m -f -; then
   echo "Error: Failed to apply metrics-server manifest" >&2
   exit 1
 fi

--- a/scripts/install-prometheus.sh
+++ b/scripts/install-prometheus.sh
@@ -40,7 +40,7 @@ grep -rl 'memory:\|cpu:' "${KUBE_PROMETHEUS_DIR}/manifests/" --include="*.yaml" 
   -e 's/cpu: "2"/cpu: 200m/g'
 
 echo "Applying kube-prometheus setup manifests (CRDs, namespace)..."
-if ! kubectl apply --server-side -f "${KUBE_PROMETHEUS_DIR}/manifests/setup/"; then
+if ! kubectl apply --server-side --timeout=5m -f "${KUBE_PROMETHEUS_DIR}/manifests/setup/"; then
   echo "Error: Failed to apply kube-prometheus setup manifests" >&2
   exit 1
 fi
@@ -50,8 +50,8 @@ kubectl wait --for condition=Established --all CustomResourceDefinition --timeou
 
 # Apply twice — first pass may fail on CRD-to-CR ordering races
 echo "Applying kube-prometheus manifests..."
-kubectl apply -f "${KUBE_PROMETHEUS_DIR}/manifests/" 2>&1 || true
-if ! kubectl apply -f "${KUBE_PROMETHEUS_DIR}/manifests/"; then
+kubectl apply --timeout=5m -f "${KUBE_PROMETHEUS_DIR}/manifests/" 2>&1 || true
+if ! kubectl apply --timeout=5m -f "${KUBE_PROMETHEUS_DIR}/manifests/"; then
   echo "Error: Failed to apply kube-prometheus manifests" >&2
   exit 1
 fi

--- a/scripts/install-thanos.sh
+++ b/scripts/install-thanos.sh
@@ -44,7 +44,7 @@ kubectl -n monitoring patch prometheus k8s --type=merge -p "{
 
 # Deploy Thanos Query and headless sidecar service
 echo "Deploying Thanos Query and services..."
-cat <<EOF | kubectl apply -f -
+cat <<EOF | kubectl apply --timeout=5m -f -
 apiVersion: v1
 kind: Service
 metadata:

--- a/scripts/setup-local-registry.sh
+++ b/scripts/setup-local-registry.sh
@@ -51,7 +51,7 @@ fi
 
 # Create ConfigMap for registry discoverability (all providers)
 echo "Configuring ${CLUSTER_PROVIDER} to use local registry..."
-cat <<EOF | kubectl apply -f -
+cat <<EOF | kubectl apply --timeout=5m -f -
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
## Summary

- Adds `--timeout=5m` to all `kubectl apply` and `oc apply` commands across scripts, `action.yml`, and CI workflows
- Prevents indefinite hangs if the cluster API server becomes unresponsive during resource application

## Files changed

- `scripts/install-ingress-nginx.sh`
- `scripts/install-cert-manager.sh`
- `scripts/install-metrics-server.sh`
- `scripts/install-prometheus.sh` (3 apply commands)
- `scripts/install-thanos.sh`
- `scripts/setup-local-registry.sh`
- `action.yml` (Calico `oc apply`)
- `.github/workflows/pre-main.yml` (2 apply commands)

## Test plan

- [ ] Verify shellcheck passes (confirmed locally via `make lint`)
- [ ] CI matrix passes on all OS/provider combinations
- [ ] Calico, cert-manager, ingress-nginx, metrics-server, prometheus, thanos install steps complete within timeout

Closes #142