### PR TITLE
Add set -euo pipefail to scripts missing it

### DIFF
--- a/scripts/bootstrap-docker.sh
+++ b/scripts/bootstrap-docker.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # Configure Docker for Kubernetes (IPv6 support and file system limits)
 # Note: Docker storage relocation is handled by quick-cleanup action
 

--- a/scripts/generate-kind-config.sh
+++ b/scripts/generate-kind-config.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Generate a KinD configuration file from parameters
 # Usage: generate-kind-config.sh <api-server-port> <api-server-address> <disable-default-cni> <ip-family> <default-node-image> <control-plane-nodes> <num-worker-nodes> <output-file> [cluster-name]

--- a/scripts/install-olm.sh
+++ b/scripts/install-olm.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 OLM_VERSION="v0.45.0"
 echo "Installing OLM version $OLM_VERSION"
 

--- a/scripts/label-worker-nodes.sh
+++ b/scripts/label-worker-nodes.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Script to apply labels to worker nodes after cluster creation
 # Usage: label-worker-nodes.sh <expected-worker-count> <comma-separated-labels>

--- a/scripts/pre-cluster-optimization.sh
+++ b/scripts/pre-cluster-optimization.sh
@@ -4,7 +4,7 @@
 # This script performs final Docker and containerd cleanup immediately
 # before creating the kind cluster to maximize available resources.
 
-set -e
+set -euo pipefail
 
 echo "=============================================="
 echo "⚡ FINAL PRE-CLUSTER OPTIMIZATION"

--- a/scripts/proactive-disk-cleanup.sh
+++ b/scripts/proactive-disk-cleanup.sh
@@ -4,8 +4,8 @@
 # This script intelligently manages disk space by performing adaptive cleanup
 # based on available space and removing unnecessary packages/directories.
 
-# Note: Using best-effort approach - don't exit on cleanup failures
-# set -e
+# Note: Using best-effort approach - individual cleanup commands use || true
+set -euo pipefail
 
 echo "=============================================="
 echo "🧹 PROACTIVE DISK SPACE MANAGEMENT"
@@ -171,8 +171,6 @@ echo "└─ /tmp partition: $(df -h /tmp | tail -1 | awk '{print $4}') free"
 
 echo ""
 echo "=== Validating minimum space requirement ==="
-# Re-enable strict error handling for final validation
-set -e
 if [ $FINAL_AVAILABLE_GB -lt 8 ]; then
   echo "❌ ERROR: Insufficient disk space (${FINAL_AVAILABLE_GB}GB). Need at least 8GB for kind cluster."
   echo "Available space breakdown:"

--- a/scripts/remove-control-plane-taint.sh
+++ b/scripts/remove-control-plane-taint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Script to remove the control plane taint from the control-plane nodes
 

--- a/scripts/remove-control-plane-taint.sh
+++ b/scripts/remove-control-plane-taint.sh
@@ -15,10 +15,10 @@ MASTER_NODES=$(kubectl get nodes --selector=node-role.kubernetes.io/master -o na
 
 # Remove the control-plane taint from the control-plane nodes
 for node in $CONTROL_PLANE_NODES; do
-	kubectl taint nodes "$node" node-role.kubernetes.io/control-plane:NoSchedule-
+	kubectl taint nodes "$node" node-role.kubernetes.io/control-plane:NoSchedule- || true
 done
 
 # Remove the master taint from the master nodes (deprecated)
 for node in $MASTER_NODES; do
-	kubectl taint nodes "$node" node-role.kubernetes.io/master:NoSchedule-
+	kubectl taint nodes "$node" node-role.kubernetes.io/master:NoSchedule- || true
 done

--- a/scripts/setup-local-registry.sh
+++ b/scripts/setup-local-registry.sh
@@ -3,7 +3,7 @@
 # Setup a local Docker registry accessible from the KinD/Minikube cluster
 # Usage: setup-local-registry.sh <port> <cluster-provider> [cluster-name]
 
-set -e
+set -euo pipefail
 
 REGISTRY_PORT="${1:-5001}"
 CLUSTER_PROVIDER="${2:-kind}"

--- a/scripts/wait-for-pods.sh
+++ b/scripts/wait-for-pods.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 if ! command -v oc >/dev/null 2>&1; then
   echo "Error: oc is not installed." >&2


### PR DESCRIPTION
## Summary

- Add `set -euo pipefail` to 9 shell scripts that were missing strict error handling: `bootstrap-docker.sh`, `generate-kind-config.sh`, `install-olm.sh`, `label-worker-nodes.sh`, `pre-cluster-optimization.sh`, `proactive-disk-cleanup.sh`, `remove-control-plane-taint.sh`, `setup-local-registry.sh`, and `wait-for-pods.sh`
- For scripts that already had `set -e` (`pre-cluster-optimization.sh`, `setup-local-registry.sh`), upgraded to the full `set -euo pipefail`
- For `proactive-disk-cleanup.sh`, replaced the commented-out `set -e` with `set -euo pipefail` and removed the redundant `set -e` re-enable later in the script (individual commands already use `|| true` for best-effort cleanup)
- Excluded `bootstrap-clients.sh` (intentional SC2207 array expansion) and `install-oc-tools.sh` (existing error handling)

## Test plan

- [x] All scripts pass `make lint` (shellcheck)
- [ ] CI matrix tests pass across all providers and OS combinations

Closes #141