### PR TITLE
Update KinD to v0.32.0 and default node image to v1.36.1

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -166,7 +166,7 @@ jobs:
             disableDefaultCNI: true
           nodes:
             - role: control-plane
-              image: kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f
+              image: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5
               extraPortMappings:
                 - containerPort: 30000
                   hostPort: 30000

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ steps:
       apiServerAddress: 0.0.0.0
       disableDefaultCni: true
       ipFamily: dual
-      defaultNodeImage: 'kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f'
-      kindVersion: v0.31.0
+      defaultNodeImage: 'kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5'
+      kindVersion: v0.32.0
       calicoVersion: v3.31.4
 
       numControlPlaneNodes: 1

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
   defaultNodeImage:
     description: 'The default node image to use for the Kubernetes cluster'
     required: false
-    default: 'kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f'
+    default: 'kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5'
   numControlPlaneNodes:
     description: 'The number of control plane nodes to use for the Kubernetes cluster'
     required: false
@@ -43,7 +43,7 @@ inputs:
   kindVersion:
     description: 'The version of KinD to use'
     required: false
-    default: 'v0.31.0'
+    default: 'v0.32.0'
   minikubeVersion:
     description: 'The version of Minikube to use'
     required: false


### PR DESCRIPTION
## Summary

- Update `kindVersion` default from `v0.31.0` to `v0.32.0`
- Update `defaultNodeImage` default from `kindest/node:v1.35.0` to `kindest/node:v1.36.1` with new SHA256 digest
- Update custom KinD config test in pre-main.yml to use the new node image

### Notable changes in [KinD v0.32.0](https://github.com/kubernetes-sigs/kind/releases/tag/v0.32.0)

- **Breaking**: containerd upgrade — must use KinD v0.32.0+ for `kind load` with new node images
- **Breaking**: Envoy replaces HAProxy for multi-control-plane load balancing
- kubeadm v1beta4 config format for Kubernetes 1.36.0+
- cgroup v1 deprecation warning

Closes #161
Jira: [CNF-25223](https://redhat.atlassian.net/browse/CNF-25223)