### PR TITLE
feat: add ubuntu-26.04 to CI test matrices

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-22.04-arm, ubuntu-24.04, ubuntu-24.04-arm]
+        os: [ubuntu-22.04, ubuntu-22.04-arm, ubuntu-24.04, ubuntu-24.04-arm, ubuntu-26.04]
         provider: [kind, minikube, k3s]
     runs-on: ${{ matrix.os }}
     env:
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-26.04]
         provider: [kind, minikube, k3s]
         nodes:
           - controlPlane: 1
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-26.04]
         provider: [kind, minikube]
     runs-on: ${{ matrix.os }}
     env:
@@ -108,7 +108,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-26.04]
         provider: [kind, minikube]
         istio-profile: [minimal, demo, default]
         exclude:
@@ -144,7 +144,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-26.04]
         provider: [kind, minikube]
     runs-on: ${{ matrix.os }}
     env:
@@ -186,7 +186,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-26.04]
         provider: [kind, minikube]
     runs-on: ${{ matrix.os }}
     env:
@@ -222,7 +222,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-26.04]
         k8s-version:
           - 'kindest/node:v1.31.0'
           - 'kindest/node:v1.30.0'
@@ -250,7 +250,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-26.04]
         driver: [docker]
     runs-on: ${{ matrix.os }}
     env:
@@ -276,7 +276,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-26.04]
         provider: [kind]
         ip-family: [dual, ipv4]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-22.04-arm, ubuntu-24.04, ubuntu-24.04-arm]
+        os: [ubuntu-22.04, ubuntu-22.04-arm, ubuntu-24.04, ubuntu-24.04-arm, ubuntu-26.04]
         provider: [kind, minikube, k3s]
         experimental: [false]
         include:


### PR DESCRIPTION
## Summary

- Add `ubuntu-26.04` to all CI test matrices in `pre-main.yml` and `nightly.yml`
- Covers basic cluster, multi-node, OLM, Istio, combined features, monitoring, Kubernetes versions, Minikube driver, and IP family test jobs
- Does not modify `runs-on: ubuntu-latest` lines or version update workflows

## Test plan

- [ ] Pre-main CI passes on ubuntu-26.04 with kind, minikube, and k3s providers
- [ ] Nightly basic-cluster-tests pass on ubuntu-26.04
- [ ] Nightly multi-node, OLM, Istio, combined, monitoring, K8s versions, Minikube driver, and IP family tests pass on ubuntu-26.04