### PR TITLE
Add KinD version auto-update nightly workflow

### DIFF
--- a/.github/workflows/kind-update.yml
+++ b/.github/workflows/kind-update.yml
@@ -1,0 +1,104 @@
+name: Update KinD Version Nightly
+on:
+  schedule:
+    - cron: '0 3 * * *' # Every day at 3am UTC
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  update-kind-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Get latest KinD release version
+        id: get_kind_version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Function to get KinD version with retries
+          get_kind_version() {
+            local retries=3
+            local delay=5
+
+            for ((i=1; i<=retries; i++)); do
+              echo "Attempt $i to fetch KinD version..."
+
+              # Make API call with timeout
+              response=$(curl -s --max-time 30 -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/kubernetes-sigs/kind/releases/latest)
+
+              if [ $? -eq 0 ] && [ -n "$response" ]; then
+                # Extract tag_name and validate it's not null/empty
+                version=$(echo "$response" | jq -r '.tag_name // empty')
+
+                if [ -n "$version" ] && [ "$version" != "null" ] && [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                  echo "Successfully fetched KinD version: $version"
+                  echo "kind_version=$version" >> $GITHUB_OUTPUT
+                  return 0
+                else
+                  echo "Invalid version format: '$version'"
+                fi
+              else
+                echo "API call failed or returned empty response"
+              fi
+
+              if [ $i -lt $retries ]; then
+                echo "Retrying in $delay seconds..."
+                sleep $delay
+              fi
+            done
+
+            echo "Failed to fetch valid KinD version after $retries attempts"
+            exit 1
+          }
+
+          get_kind_version
+
+      - name: Update default kindVersion in action.yml
+        id: update_version
+        run: |
+          version=${{ steps.get_kind_version.outputs.kind_version }}
+
+          # Double-check the version is valid before updating
+          if [ -z "$version" ] || [ "$version" = "null" ] || ! [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Invalid KinD version '$version' - aborting update"
+            exit 1
+          fi
+
+          echo "Updating KinD version to: $version"
+
+          # Extract current default under the kindVersion block
+          current_version=$(sed -n "/^  kindVersion:$/,/^  [a-zA-Z]\+:/p" action.yml | grep -o "default: '[^']*'" | sed "s/default: '\(.*\)'/\1/")
+
+          if [ -z "$current_version" ]; then
+            echo "Could not determine current KinD version from action.yml"
+            exit 1
+          fi
+
+          if [ "$current_version" = "$version" ]; then
+            echo "KinD version is already up to date ($version)"
+            echo "updated=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Update only within the kindVersion block
+          sed -i.bak -E "/^  kindVersion:$/,/^  [a-zA-Z]+:/{s/(default: ')[^']+(')/\1$version\2/}" action.yml
+          rm action.yml.bak
+
+          echo "Successfully updated KinD version from $current_version to $version"
+          echo "updated=true" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        if: steps.update_version.outputs.updated == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          commit-message: "Update KinD version to ${{ steps.get_kind_version.outputs.kind_version }}"
+          title: "Update KinD version to ${{ steps.get_kind_version.outputs.kind_version }}"
+          body: "Automated PR to update default kindVersion in action.yml to the latest release."
+          branch: "update-kind-version-${{ steps.get_kind_version.outputs.kind_version }}"
+          delete-branch: true


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/kind-update.yml` — a nightly workflow that checks for new KinD releases and creates a PR to update the `kindVersion` default in `action.yml`
- Follows the same pattern as all other version-update workflows (minikube-update.yml, calico-update.yml, etc.)
- KinD was the only dependency missing automated version updates

Closes #187