### PR TITLE
fix: Skip Calico validation when installCalico is false (#177)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -306,6 +306,7 @@ runs:
         fi
 
     - name: Validate Calico version input
+      if: ${{ inputs.installCalico != 'false' }}
       shell: bash
       env:
         GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Fixes #177

Adds an `if` guard to skip the Calico version validation step when `installCalico: false`.

Before: Unconditional GitHub API call with up to 5 retries (~5s latency) on every workflow run.
After: Skipped entirely when Calico installation is disabled, saving ~5s per run and avoiding unnecessary API quota consumption.