### PR TITLE
fix: Warn when ipFamily is used with non-KinD providers (#184)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -178,6 +178,12 @@ runs:
           exit 1
         fi
 
+    - name: Warn about ipFamily support for non-KinD providers
+      if: ${{ inputs.clusterProvider != 'kind' && inputs.ipFamily != 'ipv4' }}
+      shell: bash
+      run: |
+        echo "::warning::ipFamily '${{ inputs.ipFamily }}' is only fully supported with KinD. ${{ inputs.clusterProvider }} will use default networking (ipv4)."
+
     - name: Validate API server address input
       shell: bash
       run: |


### PR DESCRIPTION
## Summary
- Adds a `::warning::` annotation when `ipFamily` is set to anything other than `ipv4` with Minikube or k3s providers
- The `ipFamily` input is validated for all providers but only wired to KinD via `generate-kind-config.sh` — Minikube and k3s silently ignore it
- Full dual-stack support for non-KinD providers can be added as a follow-up enhancement

Fixes #184