### PR TITLE
fix: Add curl error handling and pod readiness check to install-olm.sh (#196)

### DIFF
--- a/scripts/install-olm.sh
+++ b/scripts/install-olm.sh
@@ -11,7 +11,21 @@ for cmd in curl kubectl; do
   fi
 done
 
-curl -L https://github.com/operator-framework/operator-lifecycle-manager/releases/download/$OLM_VERSION/install.sh -o install.sh
+if ! curl -fSL --retry 3 --retry-delay 5 --retry-all-errors \
+  "https://github.com/operator-framework/operator-lifecycle-manager/releases/download/$OLM_VERSION/install.sh" \
+  -o install.sh; then
+  echo "Error: Failed to download OLM install script for version $OLM_VERSION" >&2
+  exit 1
+fi
+
 chmod +x install.sh
-./install.sh $OLM_VERSION
+./install.sh "$OLM_VERSION"
 rm install.sh
+
+echo "Waiting for OLM pods to be ready..."
+kubectl wait --for=condition=ready pod --all --namespace=olm --timeout=300s || {
+  echo "Warning: Some OLM pods may not be ready yet. Continuing..."
+}
+kubectl wait --for=condition=ready pod --all --namespace=operators --timeout=60s || {
+  echo "Warning: Some operator pods may not be ready yet. Continuing..."
+}


### PR DESCRIPTION
## Summary
- Add `-fSL --retry 3 --retry-delay 5 --retry-all-errors` to curl download (matches install-istio.sh pattern)
- Add explicit error message on download failure
- Add `kubectl wait --for=condition=ready` for OLM pods in both `olm` and `operators` namespaces (matches install-cert-manager.sh pattern)
- Quote `$OLM_VERSION` in script execution

Fixes #196