### PR TITLE
fix: Add timeout to kind create cluster to prevent indefinite hangs (#178)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -842,7 +842,7 @@ runs:
     - name: Create a new Kubernetes cluster using KinD
       if: ${{ inputs.clusterProvider == 'kind' }}
       shell: bash
-      run: kind create cluster --name ${{ inputs.clusterName }} --config ${{ github.action_path }}/kind-config.yaml
+      run: timeout 600 kind create cluster --name ${{ inputs.clusterName }} --config ${{ github.action_path }}/kind-config.yaml
 
     - name: Create a new Kubernetes cluster using Minikube
       if: ${{ inputs.clusterProvider == 'minikube' }}

--- a/action.yml
+++ b/action.yml
@@ -842,7 +842,8 @@ runs:
     - name: Create a new Kubernetes cluster using KinD
       if: ${{ inputs.clusterProvider == 'kind' }}
       shell: bash
-      run: timeout 600 kind create cluster --name ${{ inputs.clusterName }} --config ${{ github.action_path }}/kind-config.yaml
+      timeout-minutes: 10
+      run: kind create cluster --name ${{ inputs.clusterName }} --config ${{ github.action_path }}/kind-config.yaml
 
     - name: Create a new Kubernetes cluster using Minikube
       if: ${{ inputs.clusterProvider == 'minikube' }}


### PR DESCRIPTION
## Summary
- Wrap `kind create cluster` with `timeout 600` (10 minutes) to prevent indefinite hangs
- If Docker daemon hangs or image pull stalls, the step now fails fast instead of blocking for the 6-hour GitHub Actions job timeout
- Uses coreutils `timeout` which is available on all Linux GitHub Actions runners

Fixes #178