### PR TITLE
fix: Pass clusterName to Minikube via --profile (#182)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -855,7 +855,8 @@ runs:
           "${{ inputs.apiServerPort }}" \
           "${{ inputs.numControlPlaneNodes }}" \
           "${{ inputs.numWorkerNodes }}" \
-          "${{ inputs.apiServerAddress }}"
+          "${{ inputs.apiServerAddress }}" \
+          "${{ inputs.clusterName }}"
 
     - name: Create a new Kubernetes cluster using k3s
       if: ${{ inputs.clusterProvider == 'k3s' }}

--- a/action.yml
+++ b/action.yml
@@ -854,7 +854,8 @@ runs:
           "${{ inputs.minikubeDriver }}" \
           "${{ inputs.apiServerPort }}" \
           "${{ inputs.numControlPlaneNodes }}" \
-          "${{ inputs.numWorkerNodes }}"
+          "${{ inputs.numWorkerNodes }}" \
+          "${{ inputs.apiServerAddress }}"
 
     - name: Create a new Kubernetes cluster using k3s
       if: ${{ inputs.clusterProvider == 'k3s' }}

--- a/scripts/start-minikube.sh
+++ b/scripts/start-minikube.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 # Script to start Minikube cluster with configuration
-# Usage: start-minikube.sh <node_image> <disable_cni> <driver> <api_port> <num_control_plane> <num_workers> [api_server_address]
-# Example: start-minikube.sh "kindest/node:v1.34.0@sha256:..." true docker 6443 1 1 0.0.0.0
+# Usage: start-minikube.sh <node_image> <disable_cni> <driver> <api_port> <num_control_plane> <num_workers> [api_server_address] [cluster_name]
+# Example: start-minikube.sh "kindest/node:v1.34.0@sha256:..." true docker 6443 1 1 0.0.0.0 minikube
 
 NODE_IMAGE="${1:-}"
 DISABLE_CNI="${2:-false}"
@@ -12,6 +12,7 @@ API_PORT="${4:-6443}"
 NUM_CONTROL_PLANE="${5:-1}"
 NUM_WORKERS="${6:-0}"
 API_SERVER_ADDRESS="${7:-0.0.0.0}"
+CLUSTER_NAME="${8:-minikube}"
 
 if [ -z "$NODE_IMAGE" ]; then
   echo "Usage: $0 <node_image> [disable_cni] [driver] [api_port] [num_control_plane] [num_workers]"
@@ -44,6 +45,10 @@ MINIKUBE_CMD="$MINIKUBE_CMD --kubernetes-version=$K8S_VERSION"
 MINIKUBE_CMD="$MINIKUBE_CMD --apiserver-port=$API_PORT"
 if [ "$API_SERVER_ADDRESS" != "0.0.0.0" ]; then
   MINIKUBE_CMD="$MINIKUBE_CMD --apiserver-ips=$API_SERVER_ADDRESS"
+fi
+
+if [ "$CLUSTER_NAME" != "minikube" ]; then
+  MINIKUBE_CMD="$MINIKUBE_CMD --profile=$CLUSTER_NAME"
 fi
 
 # Configure nodes

--- a/scripts/start-minikube.sh
+++ b/scripts/start-minikube.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 # Script to start Minikube cluster with configuration
-# Usage: start-minikube.sh <node_image> <disable_cni> <driver> <api_port> <num_control_plane> <num_workers>
-# Example: start-minikube.sh "kindest/node:v1.34.0@sha256:..." true docker 6443 1 1
+# Usage: start-minikube.sh <node_image> <disable_cni> <driver> <api_port> <num_control_plane> <num_workers> [api_server_address]
+# Example: start-minikube.sh "kindest/node:v1.34.0@sha256:..." true docker 6443 1 1 0.0.0.0
 
 NODE_IMAGE="${1:-}"
 DISABLE_CNI="${2:-false}"
@@ -11,6 +11,7 @@ DRIVER="${3:-docker}"
 API_PORT="${4:-6443}"
 NUM_CONTROL_PLANE="${5:-1}"
 NUM_WORKERS="${6:-0}"
+API_SERVER_ADDRESS="${7:-0.0.0.0}"
 
 if [ -z "$NODE_IMAGE" ]; then
   echo "Usage: $0 <node_image> [disable_cni] [driver] [api_port] [num_control_plane] [num_workers]"
@@ -41,6 +42,9 @@ MINIKUBE_CMD="$MINIKUBE_CMD --kubernetes-version=$K8S_VERSION"
 
 # Configure network settings
 MINIKUBE_CMD="$MINIKUBE_CMD --apiserver-port=$API_PORT"
+if [ "$API_SERVER_ADDRESS" != "0.0.0.0" ]; then
+  MINIKUBE_CMD="$MINIKUBE_CMD --apiserver-ips=$API_SERVER_ADDRESS"
+fi
 
 # Configure nodes
 if [ "$NUM_WORKERS" -gt 0 ]; then


### PR DESCRIPTION
## Summary
- Add `clusterName` as 8th parameter to `start-minikube.sh`
- Pass `--profile` flag to Minikube when a non-default cluster name is specified
- Wire the input through from `action.yml` to the script

**Note:** This PR includes the changes from #201 (apiServerAddress) since both modify the same parameter list. If #201 merges first, this will rebase cleanly.

Fixes #182