### PR TITLE
fix: Use kubectl instead of oc in wait-for-pods.sh (#190)

### DIFF
--- a/scripts/wait-for-pods.sh
+++ b/scripts/wait-for-pods.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-if ! command -v oc >/dev/null 2>&1; then
-  echo "Error: oc is not installed." >&2
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo "Error: kubectl is not installed." >&2
   exit 1
 fi
 
@@ -11,12 +11,12 @@ elapsed=0
 interval=10
 
 while true; do
-  if oc get pods --all-namespaces --no-headers | awk '{if ($4 != "Running" && $4 != "Completed") exit 1}'; then
+  if kubectl get pods --all-namespaces --no-headers | awk '{if ($4 != "Running" && $4 != "Completed") exit 1}'; then
     echo "All pods are running or completed"
     break
   else
     echo "Waiting for all pods to be running or completed..."
-    oc get pods --all-namespaces --no-headers | awk '{if ($4 != "Running" && $4 != "Completed") print "Pending pod: " $1 " in namespace: " $2}'
+    kubectl get pods --all-namespaces --no-headers | awk '{if ($4 != "Running" && $4 != "Completed") print "Pending pod: " $1 " in namespace: " $2}'
     sleep $interval
     elapsed=$((elapsed + interval))
     if [ $elapsed -ge $timeout ]; then


### PR DESCRIPTION
## Summary
- Replace all `oc` references with `kubectl` in `wait-for-pods.sh` (4 occurrences)
- `oc` (OpenShift CLI) is not guaranteed to be available on all cluster providers (KinD, Minikube, k3s)
- `kubectl` is the standard Kubernetes CLI and is universally available

Fixes #190