### PR TITLE
fix: Use conditional timeout for KinD cluster creation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -848,8 +848,12 @@ runs:
     - name: Create a new Kubernetes cluster using KinD
       if: ${{ inputs.clusterProvider == 'kind' }}
       shell: bash
-      timeout-minutes: 10
-      run: kind create cluster --name ${{ inputs.clusterName }} --config ${{ github.action_path }}/kind-config.yaml
+      run: |
+        if command -v timeout >/dev/null 2>&1; then
+          timeout 600 kind create cluster --name ${{ inputs.clusterName }} --config ${{ github.action_path }}/kind-config.yaml
+        else
+          kind create cluster --name ${{ inputs.clusterName }} --config ${{ github.action_path }}/kind-config.yaml
+        fi
 
     - name: Create a new Kubernetes cluster using Minikube
       if: ${{ inputs.clusterProvider == 'minikube' }}


### PR DESCRIPTION
## Summary
- timeout-minutes is not supported in composite action steps, only in workflow steps
- This broke all CI jobs after #200 was merged
- Replace with shell-level timeout 600 command, with a fallback for macOS where GNU coreutils timeout is unavailable

Fixes the regression from #200