### PR TITLE
fix: Assign unique healthz/metrics ports to k3s worker agents (#148)

### DIFF
--- a/scripts/start-k3s.sh
+++ b/scripts/start-k3s.sh
@@ -148,6 +148,10 @@ if [ "$NUM_WORKERS" -gt 0 ]; then
       sleep 5
     fi
 
+    HEALTHZ_PORT=$((10248 + i))
+    PROXY_HEALTHZ_PORT=$((10256 + i))
+    PROXY_METRICS_PORT=$((10249 + i))
+
     echo "Starting worker node: ${WORKER_NAME}..."
     sudo k3s agent \
       --server="https://127.0.0.1:${API_PORT}" \
@@ -155,7 +159,10 @@ if [ "$NUM_WORKERS" -gt 0 ]; then
       --node-name="$WORKER_NAME" \
       --data-dir="$WORKER_DATA_DIR" \
       --lb-server-port="$LB_PORT" \
-      --kubelet-arg="--port=${KUBELET_PORT}" &
+      --kubelet-arg="--port=${KUBELET_PORT}" \
+      --kubelet-arg="--healthz-port=${HEALTHZ_PORT}" \
+      --kube-proxy-arg=healthz-bind-address=127.0.0.1:${PROXY_HEALTHZ_PORT} \
+      --kube-proxy-arg=metrics-bind-address=127.0.0.1:${PROXY_METRICS_PORT} &
   done
 
   # Wait for all workers to register


### PR DESCRIPTION
## Summary
- k3s multi-node tests fail because worker agents bind kubelet healthz (10248), kube-proxy healthz (10256), and kube-proxy metrics (10249) to the same default ports
- The script already offsets `--lb-server-port` and kubelet `--port` per worker, but missed these three
- Add per-worker offsets: healthz=10248+i, proxy-healthz=10256+i, proxy-metrics=10249+i
- This was the root cause of nightly flakiness on June 28-30 and July 1

Fixes #148