### PR TITLE
fix: Add k3s server PID liveness check after backgrounding

### DIFF
--- a/scripts/start-k3s.sh
+++ b/scripts/start-k3s.sh
@@ -56,6 +56,14 @@ echo "Starting k3s server with command: sudo k3s ${K3S_ARGS[*]}"
 sudo k3s "${K3S_ARGS[@]}" &
 K3S_PID=$!
 
+# Verify the k3s server process is actually running after backgrounding
+sleep 1
+if ! kill -0 "$K3S_PID" 2>/dev/null; then
+  echo "::error::k3s server failed to start (PID $K3S_PID not running)"
+  echo "Common causes: port $API_PORT already in use, insufficient permissions, or invalid k3s flags"
+  exit 1
+fi
+
 echo "Waiting for k3s to be ready..."
 max_attempts=60
 attempt=1


### PR DESCRIPTION
## Summary

Adds an immediate PID liveness check after backgrounding the k3s server process to detect early failures.

## Problem

Currently, `start-k3s.sh` backgrounds the k3s server and captures its PID, but doesn't verify the process is actually running until much later (line 195, after workers are registered). If k3s fails immediately due to:
- Port 6443 already in use
- Insufficient permissions
- Invalid command-line flags

...the script hangs in the readiness wait loop with confusing error messages.

## Changes

- Added PID liveness check immediately after backgrounding (after 1 second delay)
- Fails fast with clear error message including common causes
- Uses GitHub Actions error annotation for visibility

## Testing

- Shellcheck passes
- Logic mirrors existing PID check at line 195
- Similar to health checks used in other provider scripts

Fixes #215