### PR TITLE
fix: Add port conflict detection for k3s multi-node workers

### DIFF
--- a/scripts/start-k3s.sh
+++ b/scripts/start-k3s.sh
@@ -116,6 +116,25 @@ fi
 if [ "$NUM_WORKERS" -gt 0 ]; then
   echo "Starting ${NUM_WORKERS} worker node(s)..."
 
+  # Check port availability before starting workers to fail fast
+  echo "Checking port availability for ${NUM_WORKERS} worker(s)..."
+  for i in $(seq 1 "$NUM_WORKERS"); do
+    HEALTHZ_PORT=$((10248 + i))
+    PROXY_HEALTHZ_PORT=$((10256 + i))
+    KUBELET_PORT=$((10250 + i))
+    LB_PORT=$((6444 + i))
+    PROXY_METRICS_PORT=$((10249 + i))
+
+    for port in $HEALTHZ_PORT $PROXY_HEALTHZ_PORT $KUBELET_PORT $LB_PORT $PROXY_METRICS_PORT; do
+      if ss -ltn 2>/dev/null | grep -q ":$port "; then
+        echo "::error::Port $port (needed for worker $i) is already in use"
+        echo "Check for existing k3s agents or other processes: sudo lsof -i :$port"
+        exit 1
+      fi
+    done
+  done
+  echo "✅ All required ports are available"
+
   token_attempts=90
   token_attempt=1
   while [ $token_attempt -le $token_attempts ]; do


### PR DESCRIPTION
## Summary

Adds port availability checks before starting k3s worker agents to detect conflicts early.

## Problem

k3s workers on the same host use incrementing ports to avoid conflicts:
- LB server: 6444+i
- Kubelet: 10250+i  
- Healthz: 10248+i
- Proxy healthz: 10256+i
- Proxy metrics: 10249+i

Currently there's no check if these ports are already in use. If another process (previous k3s agent, other service) has bound a port, the worker fails silently or with cryptic errors that don't identify the root cause.

## Changes

- Added port availability check loop before worker startup (after line 117)
- Uses `ss -ltn` to detect listening ports (same tool used in pre-cluster-optimization.sh)
- Checks all 5 ports per worker before starting any workers
- Fails fast with GitHub Actions error annotation
- Suggests diagnostic command (`lsof -i :port`) for troubleshooting

## Testing

- Shellcheck passes
- Logic mirrors port checks used elsewhere in the action
- Minimal overhead (~0.1s for port checks)

Fixes #217