### PR TITLE
fix: Swap namespace/pod labels in wait-for-pods.sh debug output

### DIFF
--- a/scripts/wait-for-pods.sh
+++ b/scripts/wait-for-pods.sh
@@ -16,7 +16,7 @@ while true; do
     break
   else
     echo "Waiting for all pods to be running or completed..."
-    kubectl get pods --all-namespaces --no-headers | awk '{if ($4 != "Running" && $4 != "Completed") print "Pending pod: " $1 " in namespace: " $2}'
+    kubectl get pods --all-namespaces --no-headers | awk '{if ($4 != "Running" && $4 != "Completed") print "Pending pod: " $2 " in namespace: " $1}'
     sleep $interval
     elapsed=$((elapsed + interval))
     if [ $elapsed -ge $timeout ]; then


### PR DESCRIPTION
## Summary

Fixes swapped labels in wait-for-pods.sh line 19. With `--all-namespaces`, kubectl columns are NAMESPACE($1) NAME($2), but the awk statement printed them backwards:

**Before:** `Pending pod: kube-system in namespace: coredns-abc`
**After:** `Pending pod: coredns-abc in namespace: kube-system`

Fixes #265