### PR TITLE
fix: Use baremetal ingress-nginx manifest for Minikube

### DIFF
--- a/scripts/install-ingress-nginx.sh
+++ b/scripts/install-ingress-nginx.sh
@@ -17,6 +17,8 @@ done
 # Use provider-specific manifest
 if [ "$CLUSTER_PROVIDER" = "kind" ]; then
   MANIFEST_URL="https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-${INGRESS_NGINX_VERSION}/deploy/static/provider/kind/deploy.yaml"
+elif [ "$CLUSTER_PROVIDER" = "minikube" ]; then
+  MANIFEST_URL="https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-${INGRESS_NGINX_VERSION}/deploy/static/provider/baremetal/deploy.yaml"
 else
   MANIFEST_URL="https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-${INGRESS_NGINX_VERSION}/deploy/static/provider/cloud/deploy.yaml"
 fi


### PR DESCRIPTION
## Summary

Minikube clusters have no cloud load balancer, so the cloud provider manifest creates a LoadBalancer Service that stays `<pending>` indefinitely. Adds a Minikube-specific branch to use the baremetal (NodePort) manifest instead.

Fixes #270