### PR TITLE
fix: Skip interactive prompts in install-oc-tools.sh for CI environments

### DIFF
--- a/scripts/install-oc-tools.sh
+++ b/scripts/install-oc-tools.sh
@@ -157,14 +157,19 @@ restore(){
 
   if ls "${BIN_PATH}/oc.${VERSION}.bak" 1> /dev/null 2>&1 && ls "${BIN_PATH}/openshift-install.${VERSION}.bak" 1> /dev/null 2>&1 && ls "${BIN_PATH}/kubectl.${VERSION}.bak" 1> /dev/null 2>&1
   then
-    read -rp "Found backup of version ${VERSION}. Restore?
-    $(echo -e "\nY/N? ")"
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
-      backup restore
-      for i in openshift-install oc kubectl; do mv "${BIN_PATH}/${i}.${VERSION}.bak" "${BIN_PATH}/${i}"; done
-      show_ver
-      exit 0
-    elif [[ $REPLY =~ ^[Nn]$ ]]; then
+    if [ -t 0 ]; then
+      read -rp "Found backup of version ${VERSION}. Restore?
+      $(echo -e "\nY/N? ")"
+      if [[ $REPLY =~ ^[Yy]$ ]]; then
+        backup restore
+        for i in openshift-install oc kubectl; do mv "${BIN_PATH}/${i}.${VERSION}.bak" "${BIN_PATH}/${i}"; done
+        show_ver
+        exit 0
+      elif [[ $REPLY =~ ^[Nn]$ ]]; then
+        echo "Downloading files..."
+      fi
+    else
+      echo "Found backup of version ${VERSION}, skipping restore (non-interactive)"
       echo "Downloading files..."
     fi
   fi
@@ -175,6 +180,10 @@ restore_version(){
 
   if ls "${BIN_PATH}/oc.${1}.bak" 1> /dev/null 2>&1 && ls "${BIN_PATH}/openshift-install.${1}.bak" 1> /dev/null 2>&1 && ls "${BIN_PATH}/kubectl.${1}.bak" 1> /dev/null 2>&1
   then
+    if [ ! -t 0 ]; then
+      echo "Found backup of version $1, skipping restore (non-interactive)"
+      return 0
+    fi
     read -rp "Found backup of version $1. Restore?
     $(echo -e "\nY/N? ")"
     if [[ $REPLY =~ ^[Yy]$ ]]; then
@@ -422,6 +431,11 @@ remove_old_ver() {
 
   if ls ${BIN_PATH}/oc*bak 1> /dev/null 2>&1 && ls ${BIN_PATH}/openshift-install*bak 1> /dev/null 2>&1 && ls ${BIN_PATH}/kubectl*bak 1> /dev/null 2>&1
   then
+  if [ ! -t 0 ]; then
+    echo "Removing old version backups (non-interactive)"
+    for i in oc kubectl openshift-install; do rm -f ${BIN_PATH}/$i*bak 2>/dev/null; done
+    exit 0
+  fi
   read -rp "Delete the following files?
 $(echo -e "\n")
 $(for i in oc kubectl openshift-install; do ls -1 ${BIN_PATH}/$i*bak 2>/dev/null; done)
@@ -451,6 +465,12 @@ uninstall(){
 
 	if ls ${BIN_PATH}/oc 1> /dev/null 2>&1 && ls ${BIN_PATH}/openshift-install 1> /dev/null 2>&1 && ls ${BIN_PATH}/kubectl 1> /dev/null 2>&1
   then
+  if [ ! -t 0 ]; then
+    echo "Uninstalling oc tools (non-interactive)"
+    for i in oc kubectl openshift-install; do rm -f ${BIN_PATH}/$i*bak 2>/dev/null; done
+    for i in oc kubectl openshift-install; do rm -f ${BIN_PATH}/$i 2>/dev/null; done
+    exit 0
+  fi
   read -rp "Delete the following files?
 $(echo -e "\n")
 $(for i in oc kubectl openshift-install; do ls -1 ${BIN_PATH}/$i 2>/dev/null; done)


### PR DESCRIPTION
## Summary

Wraps all 4 `read -rp` prompts in install-oc-tools.sh with `[ -t 0 ]` checks to detect non-interactive environments. In CI:
- Backup restore prompts are skipped (downloads fresh files)
- Cleanup/uninstall operations proceed automatically

Without this fix, the script could hang indefinitely waiting for user input in GitHub Actions.

Fixes #262