### PR TITLE
chore: Remove redundant schedule trigger from pre-main.yml

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -6,8 +6,6 @@ name: Test Changes
     branches: [main]
   pull_request:
     branches: [main]
-  schedule:
-    - cron: '0 2 * * *' # Nightly at 2AM UTC
   workflow_dispatch:
 
 permissions: read-all


### PR DESCRIPTION
## Summary

Removes the nightly 2AM UTC schedule trigger from pre-main.yml. The nightly.yml workflow already provides comprehensive nightly coverage at midnight UTC with the same tests plus additional component/multi-node/monitoring tests.

Fixes #267