### PR TITLE
fix: Extract Calico install logic into scripts/install-calico.sh

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -533,41 +533,7 @@ runs:
     - name: Install calico CNI if default CNI is disabled and installCalico is true
       if: ${{ inputs.disableDefaultCni == 'true' && inputs.installCalico == 'true' }}
       shell: bash
-      run: |
-        echo "Installing Calico CNI version $CALICO_VERSION..."
-        CALICO_URL="https://raw.githubusercontent.com/projectcalico/calico/$CALICO_VERSION/manifests/calico.yaml"
-        max_attempts=3
-        attempt=1
-        delay=5
-        while [ $attempt -le $max_attempts ]; do
-          echo "Attempt $attempt/$max_attempts: Applying Calico manifest..."
-          output=$(oc apply --timeout=5m -f "$CALICO_URL" 2>&1) && {
-            echo "$output"
-            echo "Calico CNI installed successfully"
-            break
-          }
-          exit_code=$?
-          echo "$output"
-          # Calico v3.32+ includes CRDs using CEL functions (e.g. isCIDR) not available
-          # in K8s < 1.31. The core CNI components still install correctly, so treat
-          # CRD validation errors as non-fatal if the calico-node daemonset exists.
-          if echo "$output" | grep -q "is invalid:.*compilation failed"; then
-            if oc get daemonset calico-node -n kube-system &>/dev/null; then
-              echo "Warning: Some Calico CRDs failed validation (likely K8s version incompatibility) but core components installed successfully"
-              break
-            fi
-          fi
-          if [ $attempt -eq $max_attempts ]; then
-            echo "Calico installation failed after $max_attempts attempts"
-            exit $exit_code
-          fi
-          echo "Retrying in $delay seconds..."
-          sleep $delay
-          delay=$((delay * 2))
-          attempt=$((attempt + 1))
-        done
-      env:
-        CALICO_VERSION: ${{ inputs.calicoVersion }}
+      run: ${{ github.action_path }}/scripts/install-calico.sh "${{ inputs.calicoVersion }}"
 
     - name: Skip CNI installation (bring your own CNI)
       if: ${{ inputs.disableDefaultCni == 'true' && inputs.installCalico == 'false' }}

--- a/scripts/install-calico.sh
+++ b/scripts/install-calico.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CALICO_VERSION="${1:?Usage: $0 <calico-version>}"
+
+echo "Installing Calico CNI version $CALICO_VERSION..."
+
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo "Error: kubectl is not installed." >&2
+  exit 1
+fi
+
+CALICO_URL="https://raw.githubusercontent.com/projectcalico/calico/$CALICO_VERSION/manifests/calico.yaml"
+
+max_attempts=3
+attempt=1
+delay=5
+
+while [ $attempt -le $max_attempts ]; do
+  echo "Attempt $attempt/$max_attempts: Applying Calico manifest..."
+  output=$(kubectl apply --timeout=5m -f "$CALICO_URL" 2>&1) && {
+    echo "$output"
+    echo "Calico CNI installed successfully"
+    break
+  }
+  exit_code=$?
+  echo "$output"
+
+  # Calico v3.32+ includes CRDs using CEL functions (e.g. isCIDR) not available
+  # in K8s < 1.31. The core CNI components still install correctly, so treat
+  # CRD validation errors as non-fatal if the calico-node daemonset exists.
+  if echo "$output" | grep -q "is invalid:.*compilation failed"; then
+    if kubectl get daemonset calico-node -n kube-system &>/dev/null; then
+      echo "Warning: Some Calico CRDs failed validation (likely K8s version incompatibility) but core components installed successfully"
+      break
+    fi
+  fi
+
+  if [ $attempt -eq $max_attempts ]; then
+    echo "Calico installation failed after $max_attempts attempts"
+    exit $exit_code
+  fi
+
+  echo "Retrying in $delay seconds..."
+  sleep $delay
+  delay=$((delay * 2))
+  attempt=$((attempt + 1))
+done


### PR DESCRIPTION
## Summary
- Extracted 35-line inline Calico installation from `action.yml` into `scripts/install-calico.sh`
- Switched from `oc` to `kubectl` for consistency with all other install scripts
- Preserves retry logic and CRD validation error handling
- Now linted by shellcheck alongside all other scripts

Closes #263