### PR TITLE
fix: Extract shared architecture mapping into utility function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ lint: tool-precheck
 	@failed=0; \
 	for script in $$(find scripts/ -name "*.sh" -type f); do \
 		echo "Checking: $$script"; \
-		if shellcheck "$$script"; then \
+		if shellcheck -x --source-path=scripts "$$script"; then \
 			echo "✅ $$script passed"; \
 		else \
 			echo "❌ $$script failed"; \

--- a/scripts/install-istio.sh
+++ b/scripts/install-istio.sh
@@ -14,23 +14,11 @@ for cmd in curl kubectl tar; do
   fi
 done
 
-# Determine architecture
-ARCH=$(uname -m)
-case $ARCH in
-  x86_64)
-    ARCH="amd64"
-    ;;
-  aarch64|arm64)
-    ARCH="arm64"
-    ;;
-  *)
-    echo "Error: Unsupported architecture: $ARCH" >&2
-    exit 1
-    ;;
-esac
-
-# Determine OS (Istio uses 'osx' for macOS, not 'darwin')
-OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+# shellcheck source=map-platform.sh
+source "$(dirname "$0")/map-platform.sh"
+ARCH=$(map_arch "$(uname -m)")
+OS=$(map_os "$(uname -s)")
+# Istio uses 'osx' instead of 'darwin'
 if [ "$OS" = "darwin" ]; then
   OS="osx"
 fi

--- a/scripts/install-kind.sh
+++ b/scripts/install-kind.sh
@@ -15,23 +15,10 @@ if [ -z "$VERSION" ] || [ -z "$OS" ] || [ -z "$ARCH" ]; then
   exit 1
 fi
 
-# Map OS names (GitHub Actions uses macOS, KinD uses darwin)
-# Convert to lowercase first
-OS=$(echo "$OS" | tr '[:upper:]' '[:lower:]')
-
-# Map macOS to darwin
-if [ "$OS" = "macos" ]; then
-  OS="darwin"
-fi
-
-# Map architecture names (GitHub Actions uses X64/x64/ARM64/arm64, KinD uses amd64/arm64)
-# Convert to lowercase first
-ARCH=$(echo "$ARCH" | tr '[:upper:]' '[:lower:]')
-
-# Then map to KinD's naming convention
-if [ "$ARCH" = "x64" ]; then
-  ARCH="amd64"
-fi
+# shellcheck source=map-platform.sh
+source "$(dirname "$0")/map-platform.sh"
+OS=$(map_os "$OS")
+ARCH=$(map_arch "$ARCH")
 
 # Determine the platform string for KinD
 PLATFORM="${OS}-${ARCH}"

--- a/scripts/install-minikube.sh
+++ b/scripts/install-minikube.sh
@@ -15,23 +15,10 @@ if [ -z "$VERSION" ] || [ -z "$OS" ] || [ -z "$ARCH" ]; then
   exit 1
 fi
 
-# Map OS names (GitHub Actions uses macOS, Minikube uses darwin)
-# Convert to lowercase first
-OS=$(echo "$OS" | tr '[:upper:]' '[:lower:]')
-
-# Map macOS to darwin
-if [ "$OS" = "macos" ]; then
-  OS="darwin"
-fi
-
-# Map architecture names (GitHub Actions uses X64/x64/ARM64/arm64, Minikube uses amd64/arm64)
-# Convert to lowercase first
-ARCH=$(echo "$ARCH" | tr '[:upper:]' '[:lower:]')
-
-# Then map to Minikube's naming convention
-if [ "$ARCH" = "x64" ]; then
-  ARCH="amd64"
-fi
+# shellcheck source=map-platform.sh
+source "$(dirname "$0")/map-platform.sh"
+OS=$(map_os "$OS")
+ARCH=$(map_arch "$ARCH")
 
 # Determine the platform string for Minikube
 PLATFORM="${OS}-${ARCH}"

--- a/scripts/install-operator-sdk.sh
+++ b/scripts/install-operator-sdk.sh
@@ -10,8 +10,10 @@ if ! command -v curl >/dev/null 2>&1; then
   exit 1
 fi
 
-ARCH="$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n "$(uname -m)" ;; esac)"
-OS="$(uname | awk '{print tolower($0)}')"
+# shellcheck source=map-platform.sh
+source "$(dirname "$0")/map-platform.sh"
+ARCH=$(map_arch "$(uname -m)")
+OS=$(map_os "$(uname -s)")
 
 DL_URL="https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk_${OS}_${ARCH}"
 

--- a/scripts/map-platform.sh
+++ b/scripts/map-platform.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Sourceable utility that defines map_os() and map_arch() functions.
+# Maps platform names to Go-style conventions (linux/darwin, amd64/arm64).
+#
+# Usage:
+#   source "$(dirname "$0")/map-platform.sh"
+#   OS=$(map_os "$OS")        # macos → darwin, Linux → linux
+#   ARCH=$(map_arch "$ARCH")  # x64/x86_64 → amd64, aarch64 → arm64
+
+map_os() {
+  local os="${1:-$(uname -s)}"
+  os=$(echo "$os" | tr '[:upper:]' '[:lower:]')
+  case "$os" in macos) os="darwin" ;; esac
+  echo "$os"
+}
+
+map_arch() {
+  local arch="${1:-$(uname -m)}"
+  arch=$(echo "$arch" | tr '[:upper:]' '[:lower:]')
+  case "$arch" in x86_64|x64) arch="amd64" ;; aarch64) arch="arm64" ;; esac
+  echo "$arch"
+}


### PR DESCRIPTION
## Summary
- Created `scripts/map-platform.sh` with `map_os()` and `map_arch()` functions
- Replaced duplicated platform mapping logic in `install-kind.sh`, `install-minikube.sh`, `install-istio.sh`, and `install-operator-sdk.sh`
- Updated Makefile to pass `shellcheck -x --source-path=scripts` for sourced file resolution

Net: -14 lines, single source of truth for platform name mapping.

Closes #264