### PR TITLE
Remove macOS support

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -29,7 +29,6 @@ jobs:
     needs: lint
     if: ${{ needs.lint.result == 'success' }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.experimental || false }}
     env:
       SHELL: /bin/bash
     strategy:
@@ -37,14 +36,6 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-22.04-arm, ubuntu-24.04, ubuntu-24.04-arm, ubuntu-26.04]
         provider: [kind, minikube]
-        experimental: [false]
-        include:
-          - os: macos-15-intel
-            provider: kind
-            experimental: true
-          - os: macos-15-intel
-            provider: minikube
-            experimental: true
     steps:
       - name: Checkout the code
         uses: actions/checkout@v7
@@ -54,11 +45,10 @@ jobs:
         with:
           clusterProvider: ${{ matrix.provider }}
           waitForPodsReady: true
-          # Skip OLM, Istio, and cert-manager on macOS (Colima limitations)
-          installOLM: ${{ !startsWith(matrix.os, 'macos') }}
-          installIstio: ${{ !startsWith(matrix.os, 'macos') }}
+          installOLM: true
+          installIstio: true
           istioProfile: minimal
-          installCertManager: ${{ !startsWith(matrix.os, 'macos') }}
+          installCertManager: true
           removeDefaultStorageClass: true
           removeControlPlaneTaint: true
           apiServerPort: 6443

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **quick-k8s** is a GitHub Action for deploying Kubernetes clusters on GitHub Actions runners. It's a composite action using shell scripts that supports KinD (Kubernetes in Docker), Minikube, and k3s as cluster providers, with optional Calico CNI, Istio service mesh, OLM (Operator Lifecycle Manager), and local Docker registry.
 
-**Target Environment**: Linux (Ubuntu 22.04/24.04, x86 and ARM64). macOS has limited support (Intel-only, requires paid runners with Docker nested virtualization).
+**Target Environment**: Linux (Ubuntu 22.04/24.04/26.04, x86 and ARM64).
 
 ## Commands
 
@@ -87,7 +87,6 @@ K8S_VERSION=$(echo "$NODE_IMAGE" | sed -E 's/.*:([^@]+)@.*/\1/')
 
 k3s runs as native processes (not in Docker) on the host:
 - **Version format**: `v1.33.1+k3s1` — the `+` must be URL-encoded as `%2B` in GitHub API/download URLs
-- **Linux-only**: No macOS binary exists
 - **Single control plane**: Multi-CP requires embedded etcd, not yet supported
 - **Built-in Traefik/ServiceLB disabled**: To avoid conflicts with action's ingress support
 - **Storage class**: Uses `local-path` (not `standard` like KinD/Minikube)

--- a/README.md
+++ b/README.md
@@ -20,13 +20,6 @@ Supports **KinD** (default) and **Minikube** as cluster providers.
 | `ubuntu-24.04` | x86_64 | ✅ Fully supported |
 | `ubuntu-24.04-arm` | ARM64 | ✅ Fully supported |
 | `ubuntu-26.04` | x86_64 | ✅ Fully supported |
-| `macos-15-intel` | x86_64 | ✅ Supported (see notes) |
-| `macos-14`, `macos-15` | ARM64 (M1) | ❌ Not supported |
-
-**macOS Notes:**
-- Docker is set up automatically via Colima using `douglascamata/setup-docker-macos-action`
-- OLM and Istio installation are not supported on macOS due to Colima networking limitations
-- Apple Silicon runners (`macos-14`, `macos-15`) lack nested virtualization required for Docker
 
 ## Usage:
 
@@ -199,7 +192,6 @@ steps:
 - cert-manager adds 3 pods to the cluster (controller, webhook, cainjector)
 - Requires approximately 200-300MB additional memory
 - Webhook startup may take 30-60 seconds
-- Not supported on macOS due to Colima networking limitations
 
 ### Installing ingress-nginx
 
@@ -449,7 +441,6 @@ Both cluster providers are fully supported and tested. Choose the one that best 
   - Multiple driver options (docker, podman, none)
   - Better local development experience
   - Built-in addons system
-  - GPU support (with krunkit driver on macOS)
 - ⚠️ **Considerations**: 
   - Slightly slower startup, more complex for multi-node setups
   - When disabling default CNI (`disableDefaultCni: true`), uses docker runtime instead of containerd (Minikube requirement)
@@ -592,4 +583,3 @@ This action is essentially a wrapper around best practices for deploying Kuberne
 ## References
 
 - [install-oc-tools.sh](./scripts/install-oc-tools.sh) was a script copied from [install-oc-tools](https://github.com/cptmorgan-rh/install-oc-tools) and slightly modified for `aarch64`.
-- [douglascamata/setup-docker-macos-action@v1-alpha](https://github.com/marketplace/actions/setup-docker-on-macos) is brought to help install Docker on MacOS.

--- a/action.yml
+++ b/action.yml
@@ -384,23 +384,17 @@ runs:
       shell: bash
       run: ${{ github.action_path }}/scripts/check-github-status.sh
 
-    - name: Write temporary docker file (Linux)
-      if: ${{ runner.os == 'Linux' }}
+    - name: Write temporary docker file
       shell: bash
       run: |
         mkdir -p /home/runner/.docker
         touch /home/runner/.docker/config
 
-    - name: Optimize disk space and relocate Docker storage (Linux)
-      if: ${{ runner.os == 'Linux' }}
+    - name: Optimize disk space and relocate Docker storage
       uses: palmsoftware/quick-cleanup@v0
       with:
         cleanup-mode: auto
         minimum-free-space: 8
-
-    - name: Setup Docker on Mac
-      if: ${{ runner.os == 'macOS' }}
-      uses: douglascamata/setup-docker-macos-action@v1.1.0
 
     # Cache KinD binary to avoid download failures during outages
     - name: Cache KinD binary
@@ -472,13 +466,11 @@ runs:
       shell: bash
       run: cat ${{ github.action_path }}/kind-config.yaml
 
-    - name: Configure Docker for Kubernetes (Linux)
-      if: ${{ runner.os == 'Linux' }}
+    - name: Configure Docker for Kubernetes
       shell: bash
       run: ${{ github.action_path }}/scripts/bootstrap-docker.sh
 
     - name: Final pre-cluster disk optimization
-      if: ${{ runner.os == 'Linux' }}
       shell: bash
       run: ${{ github.action_path }}/scripts/pre-cluster-optimization.sh
 
@@ -511,19 +503,10 @@ runs:
           "${{ inputs.apiServerAddress }}" \
           "${{ inputs.clusterName }}"
 
-    # - name: Bootstrap the runner with kubectl and oc clients
     - name: Bootstrap the runner with kubectl and oc clients
-      if: ${{ runner.os == 'Linux' }}
       shell: bash
       run: |
         sudo ${{ github.action_path }}/scripts/install-oc-tools.sh --latest ${{ inputs.ocpReleaseLevel }}
-
-    - name: Install oc client on MacOS
-      if: ${{ runner.os == 'macOS' }}
-      shell: bash
-      run: |
-        brew install openshift-cli
-        brew install kubernetes-cli
 
     - name: Apply labels to worker nodes
       if: ${{ inputs.workerNodeLabels != '' && inputs.numWorkerNodes > 0 }}
@@ -604,18 +587,10 @@ runs:
       shell: bash
       run: ${{ github.action_path }}/scripts/wait-for-pods.sh
 
-    - name: Clean up package manager cache (Linux)
-      if: ${{ runner.os == 'Linux' }}
+    - name: Clean up package manager cache
       shell: bash
       run: |
         sudo apt-get clean
-
-    - name: Clean up Homebrew cache (macOS)
-      if: ${{ runner.os == 'macOS' }}
-      shell: bash
-      run: |
-        brew cleanup -s
-        rm -rf ~/Library/Caches/Homebrew
 
     - name: Print cluster deployment summary
       shell: bash

--- a/scripts/install-istio.sh
+++ b/scripts/install-istio.sh
@@ -18,21 +18,10 @@ done
 source "$(dirname "$0")/map-platform.sh"
 ARCH=$(map_arch "$(uname -m)")
 OS=$(map_os "$(uname -s)")
-# Istio uses 'osx' instead of 'darwin'
-if [ "$OS" = "darwin" ]; then
-  OS="osx"
-fi
 
 echo "Detected OS: $OS, Architecture: $ARCH"
 
-# Download istioctl
-# Istio naming convention: linux-{arch}, osx (universal), osx-arm64
-if [ "$OS" = "osx" ] && [ "$ARCH" = "amd64" ]; then
-  # macOS Intel uses universal 'osx' build (not osx-amd64)
-  ISTIO_URL="https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/istio-${ISTIO_VERSION}-osx.tar.gz"
-else
-  ISTIO_URL="https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/istio-${ISTIO_VERSION}-${OS}-${ARCH}.tar.gz"
-fi
+ISTIO_URL="https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/istio-${ISTIO_VERSION}-${OS}-${ARCH}.tar.gz"
 echo "Downloading Istio from: $ISTIO_URL"
 
 if ! curl -fSL --retry 3 --retry-delay 5 --retry-all-errors "$ISTIO_URL" -o istio.tar.gz; then

--- a/scripts/install-oc-tools.sh
+++ b/scripts/install-oc-tools.sh
@@ -14,9 +14,6 @@ OS=$(uname -s)
 if [ "${OS}" == 'Linux' ]; then
   OS=linux
   OCTOOLSRC="$(getent passwd "$SUDO_USER" | cut -d: -f6)"/.octoolsrc
-elif [ "${OS}" == 'Darwin' ]; then
-  OS=mac
-  OCTOOLSRC="${HOME}"/.octoolsrc
 else
   echo "OS Unsupported: ${OS}"
   exit 99
@@ -263,11 +260,7 @@ version() {
       exit 0
     fi
     CLIENT="${MIRROR_DOMAIN}${MIRROR_PATH}/ocp/$1/openshift-client-${OS}.tar.gz"
-    if [ "${ARCH}" == 'arm64' ] && [ "${OS}" == 'Darwin' ]; then
-      INSTALL="${MIRROR_DOMAIN}${MIRROR_PATH}/ocp/$1/openshift-install-${OS}-${ARCH}.tar.gz"
-    else
-      INSTALL="${MIRROR_DOMAIN}${MIRROR_PATH}/ocp/$1/openshift-install-${OS}.tar.gz"
-    fi
+    INSTALL="${MIRROR_DOMAIN}${MIRROR_PATH}/ocp/$1/openshift-install-${OS}.tar.gz"
     download "$CLIENT" "$INSTALL"
   fi
 
@@ -294,13 +287,8 @@ release() {
       exit 0
     fi
 
-    if [ "${ARCH}" == 'arm64' ] && [ "${OS}" == 'mac' ]; then
-      CLIENT="${MIRROR_DOMAIN}${MIRROR_PATH}/ocp/$2/openshift-client-${OS}-${ARCH}.tar.gz"
-      INSTALL="${MIRROR_DOMAIN}${MIRROR_PATH}/ocp/$2/openshift-install-${OS}-${ARCH}.tar.gz"
-    else
-      CLIENT="${MIRROR_DOMAIN}${MIRROR_PATH}/ocp/$2/openshift-client-${OS}.tar.gz"
-      INSTALL="${MIRROR_DOMAIN}${MIRROR_PATH}/ocp/$2/openshift-install-${OS}.tar.gz"
-    fi
+    CLIENT="${MIRROR_DOMAIN}${MIRROR_PATH}/ocp/$2/openshift-client-${OS}.tar.gz"
+    INSTALL="${MIRROR_DOMAIN}${MIRROR_PATH}/ocp/$2/openshift-install-${OS}.tar.gz"
     download "$CLIENT" "$INSTALL"
   else
     verify_version "${MIRROR_DOMAIN}${MIRROR_PATH}/ocp/$2-$1/release.txt" "$1"
@@ -311,13 +299,8 @@ release() {
       exit 0
     fi
 
-    if [ "${ARCH}" == 'arm64' ] && [ "${OS}" == 'mac' ]; then
-      CLIENT="${MIRROR_DOMAIN}${MIRROR_PATH}/ocp/$2-$1/openshift-client-${OS}-${ARCH}.tar.gz"
-      INSTALL="${MIRROR_DOMAIN}${MIRROR_PATH}/ocp/$2-$1/openshift-install-${OS}-${ARCH}.tar.gz"
-    else
-      CLIENT="${MIRROR_DOMAIN}${MIRROR_PATH}/ocp/$2-$1/openshift-client-${OS}.tar.gz"
-      INSTALL="${MIRROR_DOMAIN}${MIRROR_PATH}/ocp/$2-$1/openshift-install-${OS}.tar.gz"
-    fi
+    CLIENT="${MIRROR_DOMAIN}${MIRROR_PATH}/ocp/$2-$1/openshift-client-${OS}.tar.gz"
+    INSTALL="${MIRROR_DOMAIN}${MIRROR_PATH}/ocp/$2-$1/openshift-install-${OS}.tar.gz"
     download "$CLIENT" "$INSTALL"
   fi
 
@@ -335,13 +318,8 @@ nightly() {
         exit 0
       fi
 
-    if [ "${ARCH}" == 'arm64' ] && [ "${OS}" == 'mac' ]; then
-      CLIENT="${MIRROR_DOMAIN}${MIRROR_PATH}/ocp-dev-preview/latest/openshift-client-${OS}-${ARCH}.tar.gz"
-      INSTALL="${MIRROR_DOMAIN}${MIRROR_PATH}/ocp/$1/openshift-install-${OS}-${ARCH}.tar.gz"
-    else
-      CLIENT="${MIRROR_DOMAIN}${MIRROR_PATH}/ocp-dev-preview/latest/openshift-client-${OS}.tar.gz"
-      INSTALL="${MIRROR_DOMAIN}${MIRROR_PATH}/ocp/$1/openshift-install-${OS}.tar.gz"
-    fi
+    CLIENT="${MIRROR_DOMAIN}${MIRROR_PATH}/ocp-dev-preview/latest/openshift-client-${OS}.tar.gz"
+    INSTALL="${MIRROR_DOMAIN}${MIRROR_PATH}/ocp/$1/openshift-install-${OS}.tar.gz"
     download "$CLIENT" "$INSTALL"
   else
     verify_version "${MIRROR_DOMAIN}${MIRROR_PATH}/ocp-dev-preview/latest-$1/release.txt" "$1"
@@ -352,11 +330,7 @@ nightly() {
       exit 0
     fi
     CLIENT="${MIRROR_DOMAIN}${MIRROR_PATH}/ocp-dev-preview/latest-$1/openshift-client-${OS}.tar.gz"
-    if [ "${ARCH}" == 'arm64' ] && [ "${OS}" == 'mac' ]; then
-      INSTALL="${MIRROR_DOMAIN}${MIRROR_PATH}/ocp/$1/openshift-install-${OS}-${ARCH}.tar.gz"
-    else
-      INSTALL="${MIRROR_DOMAIN}${MIRROR_PATH}/ocp/$1/openshift-install-${OS}.tar.gz"
-    fi
+    INSTALL="${MIRROR_DOMAIN}${MIRROR_PATH}/ocp/$1/openshift-install-${OS}.tar.gz"
     download "$CLIENT" "$INSTALL"
   fi
 
@@ -551,10 +525,7 @@ cli_path(){
 
   if [[ "$1" == "butane" ]]
   then
-    if [ "$OS" == "mac" ] && [ "$ARCH" == "x86_64" ]
-    then
-      MIRROR_CLI_PATH="${MIRROR_DOMAIN}/pub/openshift-v4/clients/butane/latest/butane-darwin-${ARCH}"
-    elif [ "$OS" != "mac" ] && [ "$ARCH" == "x86_64" ]
+    if [ "$ARCH" == "x86_64" ]
     then
       MIRROR_CLI_PATH="${MIRROR_DOMAIN}/pub/openshift-v4/clients/butane/latest/butane-amd64"
     else
@@ -574,10 +545,7 @@ cli_path(){
 
   if [[ "$1" == "helm" ]]
   then
-    if [ "$OS" == "mac" ] && [ "$ARCH" == "x86_64" ]
-    then
-      MIRROR_CLI_PATH="${MIRROR_DOMAIN}/pub/openshift-v4/clients/helm/latest/helm-darwin-${ARCH}"
-    elif [ "$OS" != "mac" ] && [ "$ARCH" == "x86_64" ]
+    if [ "$ARCH" == "x86_64" ]
     then
       MIRROR_CLI_PATH="${MIRROR_DOMAIN}/pub/openshift-v4/clients/helm/latest/helm-linux-amd64"
     else
@@ -587,10 +555,7 @@ cli_path(){
 
   if [[ "$1" == "kam" ]]
   then
-    if [ "$OS" == "mac" ] && [ "$ARCH" == "x86_64" ]
-    then
-      MIRROR_CLI_PATH="${MIRROR_DOMAIN}/pub/openshift-v4/clients/kam/latest/kam-darwin-${ARCH}"
-    elif [ "$OS" != "mac" ] && [ "$ARCH" == "x86_64" ]
+    if [ "$ARCH" == "x86_64" ]
     then
       MIRROR_CLI_PATH="${MIRROR_DOMAIN}/pub/openshift-v4/clients/kam/latest/kam-linux-amd64"
     else
@@ -600,13 +565,7 @@ cli_path(){
 
   if [[ "$1" == "odo" ]]
   then
-    if [ "$OS" == "mac" ] && [ "$ARCH" == "x86_64" ]
-    then
-      MIRROR_CLI_PATH="${MIRROR_DOMAIN}/pub/openshift-v4/clients/odo/latest/odo-darwin-${ARCH}"
-    elif [ "$OS" == "mac" ] && [ "$ARCH" == "arm64" ]
-    then
-      MIRROR_CLI_PATH="${MIRROR_DOMAIN}/pub/openshift-v4/clients/odo/latest/odo-darwin-${ARCH}"
-    elif [ "$ARCH" == "x86_64" ]
+    if [ "$ARCH" == "x86_64" ]
     then
       MIRROR_CLI_PATH="${MIRROR_DOMAIN}/pub/openshift-v4/clients/odo/latest/odo-linux-amd64"
     else
@@ -616,10 +575,7 @@ cli_path(){
 
   if [[ "$1" == "serverless" ]]
   then
-    if [ "$OS" == "mac" ]
-    then
-      MIRROR_CLI_PATH="${MIRROR_DOMAIN}/pub/openshift-v4/clients/serverless/latest/kn-macos-amd64.tar.gz"
-    elif [ "$ARCH" == "x86_64" ]
+    if [ "$ARCH" == "x86_64" ]
     then
       MIRROR_CLI_PATH="${MIRROR_DOMAIN}/pub/openshift-v4/clients/serverless/latest/kn-linux-amd64.tar.gz"
     else


### PR DESCRIPTION
## Summary

- Remove macOS CI matrix entries and `experimental`/`continue-on-error` infrastructure from `pre-main.yml`
- Remove 3 macOS-conditional steps from `action.yml` (Docker setup via Colima, brew installs, Homebrew cache cleanup)
- Remove `runner.os == 'Linux'` guards since all runners are now Linux
- Remove Darwin/osx code paths from `install-oc-tools.sh` and `install-istio.sh`
- Update README and CLAUDE.md to reflect Linux-only support

macOS CI tests consistently failed with KinD kubeadm control plane timeouts under Colima/Lima virtualization. They were already marked `continue-on-error: true` but added noise to every PR. No known users run this action on macOS runners.

Net: **-101 lines** across 6 files.

## Test plan

- [ ] All Ubuntu matrix jobs pass (no macOS jobs should appear)
- [ ] `make lint` passes
- [ ] Verify no remaining macOS references in `.github/`, `action.yml`, or `scripts/` (only `map-platform.sh` utility retains a harmless `darwin` mapping)