### PR TITLE
fix: Pass GITHUB_TOKEN to Minikube start step to prevent API rate limiting

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -492,6 +492,8 @@ runs:
     - name: Create a new Kubernetes cluster using Minikube
       if: ${{ inputs.clusterProvider == 'minikube' }}
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
         ${{ github.action_path }}/scripts/start-minikube.sh \
           "${{ inputs.defaultNodeImage }}" \


### PR DESCRIPTION
## Summary

- Adds `GITHUB_TOKEN` env var to the Minikube cluster creation step in `action.yml`
- Minikube calls the GitHub API to validate the Kubernetes version tag during `minikube start`, even when `--kubernetes-version` is explicitly passed
- Without authentication, these requests are limited to 60/hour and fail when multiple matrix jobs share runner IPs
- Authenticated requests get 5,000/hour, matching the pattern already used by 10+ other steps in the action

## Context

7 of the last 10 nightly runs have failed due to this rate limit, affecting random Minikube matrix jobs each night:

```
X Exiting due to K8S_FAIL_CONNECT: error fetching Kubernetes version list from GitHub:
GET https://api.github.com/repos/kubernetes/kubernetes/releases/tags/v1.36.1:
403 API rate limit exceeded
```

## Test plan

- [ ] CI passes on this PR (especially all Minikube matrix jobs)
- [ ] Monitor next nightly run for absence of rate limit errors