### PR TITLE
Skip Calico version validation when disableDefaultCni is false

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -214,7 +214,7 @@ runs:
       run: ${{ github.action_path }}/scripts/validate-github-version.sh "Minikube" "kubernetes/minikube" "${{ inputs.minikubeVersion }}"
 
     - name: Validate Calico version input
-      if: ${{ inputs.installCalico != 'false' }}
+      if: ${{ inputs.disableDefaultCni == 'true' && inputs.installCalico != 'false' }}
       shell: bash
       env:
         GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

- Skip the Calico version validation GitHub API call when `disableDefaultCni` is `false`, since Calico is never installed in that case (built-in CNI is used)
- Aligns the validation guard with the actual installation condition on line 529: `disableDefaultCni == 'true' && installCalico == 'true'`

Closes #271