### PR TITLE
Add minikubeDriver input validation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -213,6 +213,17 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
       run: ${{ github.action_path }}/scripts/validate-github-version.sh "Minikube" "kubernetes/minikube" "${{ inputs.minikubeVersion }}"
 
+    - name: Validate minikubeDriver input
+      if: ${{ inputs.clusterProvider == 'minikube' }}
+      shell: bash
+      run: |
+        DRIVER="${{ inputs.minikubeDriver }}"
+        if [[ "$DRIVER" != "docker" && "$DRIVER" != "podman" && "$DRIVER" != "none" ]]; then
+          echo "Invalid minikubeDriver: $DRIVER"
+          echo "Must be 'docker', 'podman', or 'none'"
+          exit 1
+        fi
+
     - name: Validate Calico version input
       if: ${{ inputs.installCalico != 'false' }}
       shell: bash


### PR DESCRIPTION
## Summary

- Add enum validation for `minikubeDriver` input, restricting to `docker`, `podman`, or `none`
- Only validates when `clusterProvider` is `minikube`
- Invalid values now fail fast with a clear error instead of cryptic Minikube failures

Closes #248