### PR TITLE
Add workflow concurrency controls to prevent duplicate runs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,6 +8,10 @@ on:
   #   branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 permissions: read-all
 
 jobs:

--- a/.github/workflows/ocp-version-update.yml
+++ b/.github/workflows/ocp-version-update.yml
@@ -4,6 +4,10 @@ on:
     - cron: '0 4 * * *' # Every day at 4am UTC
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 permissions: read-all
 
 jobs:

--- a/.github/workflows/olm-update.yml
+++ b/.github/workflows/olm-update.yml
@@ -4,6 +4,10 @@ on:
     - cron: '0 2 * * *' # Every day at 2am UTC
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 permissions: read-all
 
 jobs:

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -8,6 +8,10 @@ name: Test Changes
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions: read-all
 
 jobs:

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 permissions: read-all
 
 jobs:

--- a/.github/workflows/version-updates.yml
+++ b/.github/workflows/version-updates.yml
@@ -22,6 +22,10 @@ on:
           - kube-prometheus
           - thanos
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 permissions: read-all
 
 jobs:


### PR DESCRIPTION
## Summary

- Add `concurrency` groups to all GitHub Actions workflows
- PR/push workflows use per-PR/ref groups to cancel stale runs on rapid pushes
- Scheduled/update workflows use per-workflow groups to prevent overlapping runs

Closes #232