### PR TITLE
Add namespace filtering to wait-for-pods.sh

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -76,6 +76,14 @@ inputs:
     description: 'Wait for all pods to be ready'
     required: false
     default: 'false'
+  waitForPodsNamespaces:
+    description: 'Comma-separated list of namespaces to monitor for pod readiness. If empty, monitors all namespaces'
+    required: false
+    default: ''
+  waitForPodsExcludeNamespaces:
+    description: 'Comma-separated list of namespaces to exclude from pod readiness monitoring'
+    required: false
+    default: ''
   installIstio:
     description: 'Install Istio service mesh'
     required: false
@@ -597,6 +605,9 @@ runs:
     - name: Wait for all pods to be ready
       if: ${{ inputs.waitForPodsReady == 'true' }}
       shell: bash
+      env:
+        WAIT_NAMESPACES: ${{ inputs.waitForPodsNamespaces }}
+        EXCLUDE_NAMESPACES: ${{ inputs.waitForPodsExcludeNamespaces }}
       run: ${{ github.action_path }}/scripts/wait-for-pods.sh
 
     - name: Clean up package manager cache

--- a/scripts/wait-for-pods.sh
+++ b/scripts/wait-for-pods.sh
@@ -10,13 +10,58 @@ timeout=1200  # 20 minutes in seconds
 elapsed=0
 interval=10
 
+# Build the list of namespaces to monitor
+get_namespaces() {
+  if [ -n "${WAIT_NAMESPACES:-}" ]; then
+    # Include only specified namespaces
+    echo "$WAIT_NAMESPACES" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
+  elif [ -n "${EXCLUDE_NAMESPACES:-}" ]; then
+    # Get all namespaces and exclude specified ones
+    local all_ns
+    all_ns=$(kubectl get namespaces --no-headers -o custom-columns=':metadata.name')
+    local exclude_list
+    exclude_list=$(echo "$EXCLUDE_NAMESPACES" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+    for ns in $all_ns; do
+      if ! echo "$exclude_list" | grep -qx "$ns"; then
+        echo "$ns"
+      fi
+    done
+  fi
+}
+
+# Get pods from the appropriate namespaces
+get_pods() {
+  local namespaces
+  namespaces=$(get_namespaces)
+
+  if [ -z "$namespaces" ]; then
+    # No filtering — monitor all namespaces
+    kubectl get pods --all-namespaces --no-headers
+  else
+    # Monitor specific namespaces
+    for ns in $namespaces; do
+      kubectl get pods -n "$ns" --no-headers 2>/dev/null | awk -v ns="$ns" '{print ns " " $0}'
+    done
+  fi
+}
+
+# Log which namespaces are being monitored
+if [ -n "${WAIT_NAMESPACES:-}" ]; then
+  echo "Monitoring pods in namespaces: ${WAIT_NAMESPACES}"
+elif [ -n "${EXCLUDE_NAMESPACES:-}" ]; then
+  echo "Monitoring all namespaces except: ${EXCLUDE_NAMESPACES}"
+else
+  echo "Monitoring pods in all namespaces"
+fi
+
 while true; do
-  if kubectl get pods --all-namespaces --no-headers | awk '{if ($4 != "Running" && $4 != "Completed") exit 1}'; then
+  pod_output=$(get_pods)
+  if [ -z "$pod_output" ] || echo "$pod_output" | awk '{if ($4 != "Running" && $4 != "Completed") exit 1}'; then
     echo "All pods are running or completed"
     break
   else
     echo "Waiting for all pods to be running or completed..."
-    kubectl get pods --all-namespaces --no-headers | awk '{if ($4 != "Running" && $4 != "Completed") print "Pending pod: " $2 " in namespace: " $1}'
+    echo "$pod_output" | awk '{if ($4 != "Running" && $4 != "Completed") print "Pending pod: " $2 " in namespace: " $1}'
     sleep $interval
     elapsed=$((elapsed + interval))
     if [ $elapsed -ge $timeout ]; then


### PR DESCRIPTION
## Summary

- Add `waitForPodsNamespaces` input to monitor only specific namespaces
- Add `waitForPodsExcludeNamespaces` input to exclude namespaces from monitoring
- When neither is set, monitors all namespaces (backward compatible)
- Helps reduce false-positive timeouts from known-flaky system namespaces

Closes #237