### PR TITLE
Add global component install timeout input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -152,6 +152,10 @@ inputs:
     description: 'Port for the local Docker registry'
     required: false
     default: '5001'
+  componentTimeout:
+    description: 'Timeout in seconds for component installation (kubectl wait commands)'
+    required: false
+    default: '300'
 
 runs:
   using: 'composite'
@@ -363,6 +367,16 @@ runs:
           exit 1
         fi
 
+    - name: Validate componentTimeout input
+      shell: bash
+      run: |
+        TIMEOUT="${{ inputs.componentTimeout }}"
+        if ! [[ "$TIMEOUT" =~ ^[0-9]+$ ]] || [ "$TIMEOUT" -lt 1 ]; then
+          echo "Invalid componentTimeout: $TIMEOUT"
+          echo "Must be a positive integer (seconds)"
+          exit 1
+        fi
+
     - name: Validate kindConfigPath input
       if: ${{ inputs.kindConfigPath != '' && inputs.clusterProvider == 'kind' }}
       shell: bash
@@ -528,6 +542,8 @@ runs:
     - name: Install calico CNI if default CNI is disabled and installCalico is true
       if: ${{ inputs.disableDefaultCni == 'true' && inputs.installCalico == 'true' }}
       shell: bash
+      env:
+        COMPONENT_TIMEOUT: ${{ inputs.componentTimeout }}
       run: ${{ github.action_path }}/scripts/install-calico.sh "${{ inputs.calicoVersion }}"
 
     - name: Skip CNI installation (bring your own CNI)
@@ -545,26 +561,36 @@ runs:
     - name: Install OLM
       if: ${{ inputs.installOLM == 'true' }}
       shell: bash
+      env:
+        COMPONENT_TIMEOUT: ${{ inputs.componentTimeout }}
       run: ${{ github.action_path }}/scripts/install-olm.sh
 
     - name: Install Istio
       if: ${{ inputs.installIstio == 'true' }}
       shell: bash
+      env:
+        COMPONENT_TIMEOUT: ${{ inputs.componentTimeout }}
       run: ${{ github.action_path }}/scripts/install-istio.sh ${{ inputs.istioVersion }} ${{ inputs.istioProfile }}
 
     - name: Install cert-manager
       if: ${{ inputs.installCertManager == 'true' }}
       shell: bash
+      env:
+        COMPONENT_TIMEOUT: ${{ inputs.componentTimeout }}
       run: ${{ github.action_path }}/scripts/install-cert-manager.sh ${{ inputs.certManagerVersion }}
 
     - name: Install ingress-nginx
       if: ${{ inputs.installIngressNginx == 'true' }}
       shell: bash
+      env:
+        COMPONENT_TIMEOUT: ${{ inputs.componentTimeout }}
       run: ${{ github.action_path }}/scripts/install-ingress-nginx.sh ${{ inputs.ingressNginxVersion }} ${{ inputs.clusterProvider }}
 
     - name: Install metrics-server
       if: ${{ inputs.installMetricsServer == 'true' }}
       shell: bash
+      env:
+        COMPONENT_TIMEOUT: ${{ inputs.componentTimeout }}
       run: ${{ github.action_path }}/scripts/install-metrics-server.sh ${{ inputs.metricsServerVersion }}
 
     - name: Install operator-sdk
@@ -575,11 +601,15 @@ runs:
     - name: Install Prometheus monitoring stack
       if: ${{ inputs.enableClusterMonitoring == 'true' }}
       shell: bash
+      env:
+        COMPONENT_TIMEOUT: ${{ inputs.componentTimeout }}
       run: ${{ github.action_path }}/scripts/install-prometheus.sh ${{ inputs.kubePrometheusVersion }}
 
     - name: Install Thanos
       if: ${{ inputs.enableClusterMonitoring == 'true' }}
       shell: bash
+      env:
+        COMPONENT_TIMEOUT: ${{ inputs.componentTimeout }}
       run: ${{ github.action_path }}/scripts/install-thanos.sh ${{ inputs.thanosVersion }}
 
     - name: Remove the default storage class

--- a/scripts/install-cert-manager.sh
+++ b/scripts/install-cert-manager.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 CERT_MANAGER_VERSION="${1:-v1.19.3}"
+TIMEOUT="${COMPONENT_TIMEOUT:-300}"
 
 echo "Installing cert-manager version $CERT_MANAGER_VERSION"
 
@@ -22,7 +23,7 @@ if ! kubectl apply --timeout=5m -f "$MANIFEST_URL"; then
 fi
 
 echo "Waiting for cert-manager pods to be ready..."
-kubectl wait --for=condition=ready pod --all --namespace=cert-manager --timeout=300s || {
+kubectl wait --for=condition=ready pod --all --namespace=cert-manager --timeout="${TIMEOUT}s" || {
   echo "Warning: Some cert-manager pods may not be ready yet. Continuing..."
 }
 

--- a/scripts/install-ingress-nginx.sh
+++ b/scripts/install-ingress-nginx.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 INGRESS_NGINX_VERSION="${1:-v1.14.3}"
 CLUSTER_PROVIDER="${2:-kind}"
+TIMEOUT="${COMPONENT_TIMEOUT:-300}"
 
 echo "Installing ingress-nginx version $INGRESS_NGINX_VERSION for $CLUSTER_PROVIDER"
 
@@ -34,7 +35,7 @@ echo "Waiting for ingress-nginx controller to be ready..."
 kubectl wait --namespace ingress-nginx \
   --for=condition=ready pod \
   --selector=app.kubernetes.io/component=controller \
-  --timeout=300s || {
+  --timeout="${TIMEOUT}s" || {
   echo "Warning: ingress-nginx controller may not be ready yet. Continuing..."
 }
 

--- a/scripts/install-istio.sh
+++ b/scripts/install-istio.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ISTIO_VERSION="${1:-1.28.1}"
 ISTIO_PROFILE="${2:-minimal}"
+TIMEOUT="${COMPONENT_TIMEOUT:-300}"
 
 echo "Installing Istio version $ISTIO_VERSION with profile $ISTIO_PROFILE"
 
@@ -67,7 +68,7 @@ echo "Waiting for Istio control plane pods to be ready..."
 kubectl wait --for=condition=ready pod \
   --all \
   --namespace=istio-system \
-  --timeout=300s || {
+  --timeout="${TIMEOUT}s" || {
     echo "Warning: Some Istio pods may not be ready yet. Continuing..."
   }
 

--- a/scripts/install-metrics-server.sh
+++ b/scripts/install-metrics-server.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 METRICS_SERVER_VERSION="${1:-v0.8.1}"
+TIMEOUT="${COMPONENT_TIMEOUT:-300}"
 
 echo "Installing metrics-server version $METRICS_SERVER_VERSION"
 
@@ -29,7 +30,7 @@ echo "Waiting for metrics-server to be ready..."
 kubectl wait --namespace kube-system \
   --for=condition=ready pod \
   --selector=k8s-app=metrics-server \
-  --timeout=300s || {
+  --timeout="${TIMEOUT}s" || {
   echo "Warning: metrics-server may not be ready yet. Continuing..."
 }
 

--- a/scripts/install-olm.sh
+++ b/scripts/install-olm.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 OLM_VERSION="v0.45.0"
+TIMEOUT="${COMPONENT_TIMEOUT:-300}"
 echo "Installing OLM version $OLM_VERSION"
 
 for cmd in curl kubectl; do
@@ -23,9 +24,9 @@ chmod +x install.sh
 rm install.sh
 
 echo "Waiting for OLM pods to be ready..."
-kubectl wait --for=condition=ready pod --all --namespace=olm --timeout=300s || {
+kubectl wait --for=condition=ready pod --all --namespace=olm --timeout="${TIMEOUT}s" || {
   echo "Warning: Some OLM pods may not be ready yet. Continuing..."
 }
-kubectl wait --for=condition=ready pod --all --namespace=operators --timeout=60s || {
+kubectl wait --for=condition=ready pod --all --namespace=operators --timeout="${TIMEOUT}s" || {
   echo "Warning: Some operator pods may not be ready yet. Continuing..."
 }

--- a/scripts/install-prometheus.sh
+++ b/scripts/install-prometheus.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 KUBE_PROMETHEUS_VERSION="${1:-v0.14.0}"
+TIMEOUT="${COMPONENT_TIMEOUT:-300}"
 
 echo "Installing kube-prometheus version $KUBE_PROMETHEUS_VERSION"
 
@@ -57,7 +58,7 @@ if ! kubectl apply --timeout=5m -f "${KUBE_PROMETHEUS_DIR}/manifests/"; then
 fi
 
 echo "Waiting for monitoring pods to be ready..."
-kubectl wait --for=condition=ready pod --all --namespace=monitoring --timeout=300s || {
+kubectl wait --for=condition=ready pod --all --namespace=monitoring --timeout="${TIMEOUT}s" || {
   echo "Warning: Some monitoring pods may not be ready yet. Continuing..."
 }
 

--- a/scripts/install-thanos.sh
+++ b/scripts/install-thanos.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 THANOS_VERSION="${1:-v0.37.2}"
+TIMEOUT="${COMPONENT_TIMEOUT:-300}"
 
 echo "Installing Thanos version $THANOS_VERSION"
 
@@ -118,12 +119,12 @@ spec:
 EOF
 
 echo "Waiting for Prometheus to restart with Thanos sidecar..."
-kubectl rollout status statefulset/prometheus-k8s -n monitoring --timeout=300s || {
+kubectl rollout status statefulset/prometheus-k8s -n monitoring --timeout="${TIMEOUT}s" || {
   echo "Warning: Prometheus may still be restarting. Continuing..."
 }
 
 echo "Waiting for Thanos Query to be ready..."
-kubectl rollout status deployment/thanos-query -n monitoring --timeout=300s || {
+kubectl rollout status deployment/thanos-query -n monitoring --timeout="${TIMEOUT}s" || {
   echo "Warning: Thanos Query may not be ready yet. Continuing..."
 }
 


### PR DESCRIPTION
## Summary

- Add `componentTimeout` input (default: `300` seconds) to configure kubectl wait timeouts
- Replace hardcoded 300s timeouts across all component install scripts
- Validates input is a positive integer
- Helps environments with slow networks or constrained runners avoid false-positive timeouts

Closes #238