### PR TITLE
Add KinD extraPortMappings input for NodePort services

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -144,6 +144,10 @@ inputs:
     description: 'Path to custom KinD configuration file. When provided, uses this instead of auto-generated config'
     required: false
     default: ''
+  extraPortMappings:
+    description: 'Comma-separated list of host:container port mappings for KinD nodes (e.g., "80:30080,443:30443"). Only applies to KinD provider'
+    required: false
+    default: ''
   installLocalRegistry:
     description: 'Install a local Docker registry accessible from the cluster'
     required: false
@@ -462,6 +466,8 @@ runs:
     - name: Populate temporary config file for KinD (auto-generated)
       if: ${{ inputs.clusterProvider == 'kind' && inputs.kindConfigPath == '' }}
       shell: bash
+      env:
+        EXTRA_PORT_MAPPINGS: ${{ inputs.extraPortMappings }}
       run: ${{ github.action_path }}/scripts/generate-kind-config.sh ${{ inputs.apiServerPort }} ${{ inputs.apiServerAddress }} ${{ inputs.disableDefaultCni }} ${{ inputs.ipFamily }} ${{ inputs.defaultNodeImage }} ${{ inputs.numControlPlaneNodes }} ${{ inputs.numWorkerNodes }} ${{ github.action_path }}/kind-config.yaml ${{ inputs.clusterName }}
 
     - name: Use custom KinD config file

--- a/scripts/generate-kind-config.sh
+++ b/scripts/generate-kind-config.sh
@@ -52,6 +52,21 @@ cat >> "${FILE_NAME}" <<EOF
   - role: control-plane
     image: "${DEFAULT_NODE_IMAGE}"
 EOF
+
+  # Add extraPortMappings to control-plane nodes if specified
+  if [ -n "${EXTRA_PORT_MAPPINGS:-}" ]; then
+    echo "    extraPortMappings:" >> "${FILE_NAME}"
+    IFS=',' read -ra MAPPINGS <<< "${EXTRA_PORT_MAPPINGS}"
+    for mapping in "${MAPPINGS[@]}"; do
+      host_port="${mapping%%:*}"
+      container_port="${mapping##*:}"
+      cat >> "${FILE_NAME}" <<EOF
+      - containerPort: ${container_port}
+        hostPort: ${host_port}
+        protocol: TCP
+EOF
+    done
+  fi
 done
 
 for ((i=1; i<="${NUM_WORKER_NODES}"; i++)); do


### PR DESCRIPTION
## Summary

- Add `extraPortMappings` input accepting comma-separated `host:container` port pairs (e.g., `80:30080,443:30443`)
- Generates KinD `extraPortMappings` config without requiring a full custom `kindConfigPath`
- Only applies to KinD provider; ignored for Minikube/k3s

Closes #243