### PR TITLE
Pin nightly K8s version test images with sha256 digests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -350,8 +350,8 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, ubuntu-26.04]
         k8s-version:
-          - 'kindest/node:v1.31.0'
-          - 'kindest/node:v1.30.0'
+          - 'kindest/node:v1.31.0@sha256:25a3504b2b340954595fa7a6ed1575ef2edadf5abd83c0776a4308b64bf47c93'
+          - 'kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e'
     runs-on: ${{ matrix.os }}
     env:
       SHELL: /bin/bash


### PR DESCRIPTION
## Summary

- Pin `kindest/node` image references in nightly.yml kubernetes-versions-test with sha256 digests
- Matches the pinning approach used by the default `nodeImage` input in action.yml
- Prevents mutable tag references from causing inconsistent test results

Closes #266