### PR TITLE
Dump pod state on wait-for-pods timeout for debugging

### DIFF
--- a/scripts/wait-for-pods.sh
+++ b/scripts/wait-for-pods.sh
@@ -66,6 +66,16 @@ while true; do
     elapsed=$((elapsed + interval))
     if [ $elapsed -ge $timeout ]; then
       echo "Timeout reached: Not all pods are running or completed"
+      echo ""
+      echo "=== Pod State Dump (all namespaces) ==="
+      kubectl get pods -A
+      echo ""
+      echo "=== Describing non-Running pods ==="
+      kubectl get pods -A --no-headers | awk '$4 != "Running" && $4 != "Completed" && $4 != "Succeeded" {print $1, $2}' | while read -r ns pod; do
+        echo "--- Describing ${ns}/${pod} ---"
+        kubectl describe pod "$pod" -n "$ns"
+        echo ""
+      done
       exit 1
     fi
   fi


### PR DESCRIPTION
## Summary

- When `wait-for-pods.sh` hits its 20-minute timeout, it now dumps `kubectl get pods -A` and `kubectl describe` for any pods not in Running/Completed/Succeeded state
- This makes failure context immediately visible in CI logs, saving significant debugging time

Fixes #249

## Test plan

- [ ] CI lint job passes (shellcheck)
- [ ] Integration tests pass (existing wait-for-pods coverage)
- [ ] Manually verify: on a timeout, the pod state dump appears in logs before the exit