### PR TITLE
Emit warning when Minikube numControlPlaneNodes > 1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -497,6 +497,12 @@ runs:
           exit 1
         fi
 
+    - name: Warn about Minikube multi-control-plane limitation
+      if: ${{ inputs.clusterProvider == 'minikube' && inputs.numControlPlaneNodes > 1 }}
+      shell: bash
+      run: |
+        echo "::warning::Minikube does not support true multi-control-plane HA. Setting numControlPlaneNodes > 1 creates additional generic nodes, not actual control planes."
+
     - name: Validate number of worker nodes
       shell: bash
       run: |


### PR DESCRIPTION
## Summary

- Adds a ::warning:: annotation when clusterProvider is minikube and numControlPlaneNodes > 1
- Minikube's --nodes=N creates N identical nodes with no control-plane vs worker distinction, so extra control plane nodes are just generic nodes, not actual HA control planes
- Warning is placed in the validation section of action.yml, following the same pattern as the existing ipFamily provider warning

Closes #251