### PR TITLE
Update marketplace branding icon from box to server

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: 'Quick K8s'
 description: 'Quickly deploy a k8s cluster on Github Actions hosted runners'
 branding:
-  icon: 'box'
+  icon: 'server'
   color: 'blue'
 inputs:
   apiServerPort:


### PR DESCRIPTION
## Summary
- Change the GitHub Marketplace branding icon from `box` to `server` in `action.yml`
- The `server` icon better communicates the action's purpose of deploying Kubernetes clusters

Closes #153