### PR TITLE
Add connection details to cluster deployment summary

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -899,7 +899,16 @@ runs:
         if [ "${{ inputs.enableClusterMonitoring }}" = "true" ]; then echo "  - Prometheus/Thanos monitoring"; fi
         if [ "${{ inputs.installLocalRegistry }}" = "true" ]; then echo "  - Local registry @ localhost:${{ inputs.localRegistryPort }}"; fi
         echo ""
-        echo "Kubeconfig: ~/.kube/config"
+        echo "Connection Details:"
+        KUBECONFIG_PATH="${KUBECONFIG:-$HOME/.kube/config}"
+        echo "  Kubeconfig:  $KUBECONFIG_PATH"
+        API_SERVER=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}' 2>/dev/null) || API_SERVER="unavailable"
+        echo "  API Server:  $API_SERVER"
+        CONTEXT=$(kubectl config current-context 2>/dev/null) || CONTEXT="unavailable"
+        echo "  Context:     $CONTEXT"
+        if [ "${{ inputs.installLocalRegistry }}" = "true" ]; then
+          echo "  Registry:    localhost:${{ inputs.localRegistryPort }}"
+        fi
         echo ""
         kubectl get nodes 2>/dev/null || true
         echo ""


### PR DESCRIPTION
## Summary

- Enhance the deployment summary step to include cluster connection details: kubeconfig path, API server URL, kubectl context name, and registry URL (when local registry is enabled)
- Replace the static `Kubeconfig: ~/.kube/config` line with a structured "Connection Details" section that dynamically resolves values from the live cluster

## Changes

The "Print cluster deployment summary" step now shows:

- **Kubeconfig**: Uses `$KUBECONFIG` env var if set, falls back to `~/.kube/config`
- **API Server**: Retrieved via `kubectl config view --minify`
- **Context**: Retrieved via `kubectl config current-context`
- **Registry**: Shown conditionally when `installLocalRegistry` is enabled

All kubectl commands include error handling with fallback to "unavailable" if the cluster is not reachable.

Closes #240

## Test plan

- [ ] Verify deployment summary includes connection details in KinD CI jobs
- [ ] Verify deployment summary includes connection details in Minikube CI jobs
- [ ] Verify registry URL appears when `installLocalRegistry: true`
- [ ] Verify registry URL is omitted when `installLocalRegistry: false`