### PR TITLE
Add Kubernetes version to deployment summary output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -877,6 +877,7 @@ runs:
       if: ${{ inputs.dryRun != 'true' }}
       shell: bash
       run: |
+        K8S_VERSION=$(kubectl version -o json 2>/dev/null | jq -r '.serverVersion.gitVersion' 2>/dev/null) || K8S_VERSION="unknown"
         echo ""
         echo "======================================"
         echo "  Quick-K8s Deployment Summary"
@@ -884,6 +885,7 @@ runs:
         echo ""
         echo "Provider:     ${{ inputs.clusterProvider }}"
         echo "Cluster:      ${{ inputs.clusterName }}"
+        echo "K8s Version:  ${K8S_VERSION}"
         echo "CP Nodes:     ${{ inputs.numControlPlaneNodes }}"
         echo "Worker Nodes: ${{ inputs.numWorkerNodes }}"
         echo "IP Family:    ${{ inputs.ipFamily }}"


### PR DESCRIPTION
## Summary

- Queries the Kubernetes server version from the running cluster via `kubectl version -o json` and displays it in the deployment summary step
- The version appears between the cluster name and node count lines, making it easy to see which K8s version was deployed
- Falls back to "unknown" if the version cannot be retrieved

Closes #268