### PR TITLE
Add monitoring stack access instructions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -847,6 +847,11 @@ runs:
         COMPONENT_TIMEOUT: ${{ inputs.componentTimeout }}
       run: ${{ github.action_path }}/scripts/install-thanos.sh ${{ inputs.thanosVersion }}
 
+    - name: Print monitoring access instructions
+      if: ${{ (inputs.installMetricsServer == 'true' || inputs.enableClusterMonitoring == 'true') && inputs.dryRun != 'true' }}
+      shell: bash
+      run: ${{ github.action_path }}/scripts/print-monitoring-info.sh "${{ inputs.installMetricsServer }}" "${{ inputs.enableClusterMonitoring }}"
+
     - name: Remove the default storage class
       if: ${{ inputs.removeDefaultStorageClass == 'true' && inputs.dryRun != 'true' }}
       shell: bash

--- a/scripts/print-monitoring-info.sh
+++ b/scripts/print-monitoring-info.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Print access instructions for installed monitoring components.
+# Arguments:
+#   $1 - "true" if metrics-server is installed
+#   $2 - "true" if cluster monitoring (kube-prometheus + Thanos) is installed
+
+METRICS_SERVER="${1:-false}"
+CLUSTER_MONITORING="${2:-false}"
+
+if [ "$METRICS_SERVER" != "true" ] && [ "$CLUSTER_MONITORING" != "true" ]; then
+  exit 0
+fi
+
+echo ""
+echo "======================================"
+echo "  Monitoring Access Instructions"
+echo "======================================"
+
+if [ "$METRICS_SERVER" = "true" ]; then
+  echo ""
+  echo "--- metrics-server ---"
+  echo ""
+  echo "  metrics-server provides resource usage data (no web UI)."
+  echo ""
+  echo "  Query resource usage:"
+  echo "    kubectl top nodes"
+  echo "    kubectl top pods -A"
+  echo "    kubectl top pods -n <namespace>"
+  echo ""
+  echo "  Raw metrics API:"
+  echo "    kubectl get --raw /apis/metrics.k8s.io/v1beta1/nodes"
+  echo "    kubectl get --raw /apis/metrics.k8s.io/v1beta1/pods"
+fi
+
+if [ "$CLUSTER_MONITORING" = "true" ]; then
+  echo ""
+  echo "--- Prometheus ---"
+  echo ""
+  echo "  Namespace: monitoring"
+  echo "  Service:   prometheus-k8s"
+  echo "  Port:      9090"
+  echo ""
+  echo "  Port-forward:"
+  echo "    kubectl port-forward -n monitoring svc/prometheus-k8s 9090:9090"
+  echo "  Then open: http://localhost:9090"
+  echo ""
+  echo "--- Alertmanager ---"
+  echo ""
+  echo "  Namespace: monitoring"
+  echo "  Service:   alertmanager-main"
+  echo "  Port:      9093"
+  echo ""
+  echo "  Port-forward:"
+  echo "    kubectl port-forward -n monitoring svc/alertmanager-main 9093:9093"
+  echo "  Then open: http://localhost:9093"
+  echo ""
+  echo "--- Grafana ---"
+  echo ""
+  echo "  Namespace: monitoring"
+  echo "  Service:   grafana"
+  echo "  Port:      3000"
+  echo ""
+  echo "  Port-forward:"
+  echo "    kubectl port-forward -n monitoring svc/grafana 3000:3000"
+  echo "  Then open: http://localhost:3000"
+  echo "  Default credentials: admin / admin"
+  echo ""
+  echo "--- Thanos Query ---"
+  echo ""
+  echo "  Namespace: monitoring"
+  echo "  Service:   thanos-query"
+  echo "  Port:      9090"
+  echo ""
+  echo "  Port-forward:"
+  echo "    kubectl port-forward -n monitoring svc/thanos-query 10902:9090"
+  echo "  Then open: http://localhost:10902"
+  echo ""
+  echo "--- List all monitoring services ---"
+  echo ""
+  echo "  kubectl get svc -n monitoring"
+fi
+
+echo ""
+echo "======================================"


### PR DESCRIPTION
## Summary

- Add `scripts/print-monitoring-info.sh` that prints access instructions for installed monitoring components
- Add a new step in `action.yml` that runs after monitoring installation to display service info
- For **metrics-server**: prints `kubectl top` commands and raw metrics API endpoints (no web UI)
- For **cluster monitoring** (kube-prometheus + Thanos): prints service names, namespaces, port-forward commands, and URLs for Prometheus, Alertmanager, Grafana, and Thanos Query

## Test plan

- [ ] Verify `make lint` passes (shellcheck on all scripts)
- [ ] Verify monitoring info step only runs when `installMetricsServer` or `enableClusterMonitoring` is true
- [ ] Verify the step is skipped during dry-run mode
- [ ] CI matrix tests exercise the monitoring codepath

Closes #230