### PR TITLE
fix: Standardize on kubectl instead of oc for Kubernetes operations

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -739,7 +739,7 @@ runs:
           "${{ inputs.apiServerAddress }}" \
           "${{ inputs.clusterName }}"
 
-    - name: Bootstrap the runner with kubectl and oc clients
+    - name: Bootstrap the runner with kubectl client
       if: ${{ inputs.dryRun != 'true' }}
       shell: bash
       run: |
@@ -851,7 +851,7 @@ runs:
       if: ${{ inputs.removeDefaultStorageClass == 'true' && inputs.dryRun != 'true' }}
       shell: bash
       run: |
-        oc delete storageclass standard --ignore-not-found
+        kubectl delete storageclass standard --ignore-not-found
 
     - name: Remove the control plane taint
       if: ${{ inputs.removeControlPlaneTaint == 'true' && inputs.dryRun != 'true' }}


### PR DESCRIPTION
## Summary

- Replace `oc delete storageclass` with `kubectl delete storageclass` in the storage class removal step
- Update the bootstrap step name from "kubectl and oc clients" to "kubectl client"

This action deploys vanilla Kubernetes clusters (KinD/Minikube/k3s), not OpenShift, so `kubectl` is the appropriate tool for cluster operations. Using `oc` for standard Kubernetes operations adds confusion and an unnecessary dependency.

Fixes #241