### PR TITLE
Add ::group::/::endgroup:: log annotations to scripts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -883,6 +883,7 @@ runs:
       if: ${{ inputs.dryRun != 'true' }}
       shell: bash
       run: |
+        K8S_VERSION=$(kubectl version -o json 2>/dev/null | jq -r '.serverVersion.gitVersion' 2>/dev/null) || K8S_VERSION="unknown"
         echo ""
         echo "======================================"
         echo "  Quick-K8s Deployment Summary"
@@ -890,6 +891,7 @@ runs:
         echo ""
         echo "Provider:     ${{ inputs.clusterProvider }}"
         echo "Cluster:      ${{ inputs.clusterName }}"
+        echo "K8s Version:  ${K8S_VERSION}"
         echo "CP Nodes:     ${{ inputs.numControlPlaneNodes }}"
         echo "Worker Nodes: ${{ inputs.numWorkerNodes }}"
         echo "IP Family:    ${{ inputs.ipFamily }}"

--- a/action.yml
+++ b/action.yml
@@ -911,6 +911,45 @@ runs:
         echo ""
         echo "======================================"
 
+        # Write deployment summary to GitHub Step Summary
+        if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+          COMPONENTS=""
+          if [ "${{ inputs.installCalico }}" = "true" ]; then COMPONENTS="${COMPONENTS}Calico CNI ${{ inputs.calicoVersion }}, "; fi
+          if [ "${{ inputs.installIstio }}" = "true" ]; then COMPONENTS="${COMPONENTS}Istio ${{ inputs.istioVersion }} (${{ inputs.istioProfile }}), "; fi
+          if [ "${{ inputs.installOLM }}" = "true" ]; then COMPONENTS="${COMPONENTS}OLM, "; fi
+          if [ "${{ inputs.installCertManager }}" = "true" ]; then COMPONENTS="${COMPONENTS}cert-manager ${{ inputs.certManagerVersion }}, "; fi
+          if [ "${{ inputs.installIngressNginx }}" = "true" ]; then COMPONENTS="${COMPONENTS}ingress-nginx ${{ inputs.ingressNginxVersion }}, "; fi
+          if [ "${{ inputs.installMetricsServer }}" = "true" ]; then COMPONENTS="${COMPONENTS}metrics-server ${{ inputs.metricsServerVersion }}, "; fi
+          if [ "${{ inputs.installOperatorSdk }}" = "true" ]; then COMPONENTS="${COMPONENTS}operator-sdk ${{ inputs.operatorSdkVersion }}, "; fi
+          if [ "${{ inputs.enableClusterMonitoring }}" = "true" ]; then COMPONENTS="${COMPONENTS}Prometheus/Thanos monitoring, "; fi
+          if [ "${{ inputs.installLocalRegistry }}" = "true" ]; then COMPONENTS="${COMPONENTS}Local registry (localhost:${{ inputs.localRegistryPort }}), "; fi
+          # Remove trailing comma and space
+          COMPONENTS="${COMPONENTS%, }"
+          if [ -z "$COMPONENTS" ]; then COMPONENTS="None"; fi
+
+          {
+            echo "## Cluster Deployment Summary"
+            echo ""
+            echo "| Property | Value |"
+            echo "|----------|-------|"
+            echo "| Provider | ${{ inputs.clusterProvider }} |"
+            echo "| Cluster Name | ${{ inputs.clusterName }} |"
+            echo "| Control Plane Nodes | ${{ inputs.numControlPlaneNodes }} |"
+            echo "| Worker Nodes | ${{ inputs.numWorkerNodes }} |"
+            echo "| IP Family | ${{ inputs.ipFamily }} |"
+            echo "| Components | ${COMPONENTS} |"
+            echo "| Kubeconfig | \`~/.kube/config\` |"
+            echo ""
+            echo "<details>"
+            echo "<summary>Cluster Nodes</summary>"
+            echo ""
+            echo "\`\`\`"
+            kubectl get nodes 2>/dev/null || echo "Unable to retrieve node information"
+            echo "\`\`\`"
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+        fi
+
     - name: Remove temporary files
       if: ${{ inputs.dryRun != 'true' }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -905,7 +905,16 @@ runs:
         if [ "${{ inputs.enableClusterMonitoring }}" = "true" ]; then echo "  - Prometheus/Thanos monitoring"; fi
         if [ "${{ inputs.installLocalRegistry }}" = "true" ]; then echo "  - Local registry @ localhost:${{ inputs.localRegistryPort }}"; fi
         echo ""
-        echo "Kubeconfig: ~/.kube/config"
+        echo "Connection Details:"
+        KUBECONFIG_PATH="${KUBECONFIG:-$HOME/.kube/config}"
+        echo "  Kubeconfig:  $KUBECONFIG_PATH"
+        API_SERVER=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}' 2>/dev/null) || API_SERVER="unavailable"
+        echo "  API Server:  $API_SERVER"
+        CONTEXT=$(kubectl config current-context 2>/dev/null) || CONTEXT="unavailable"
+        echo "  Context:     $CONTEXT"
+        if [ "${{ inputs.installLocalRegistry }}" = "true" ]; then
+          echo "  Registry:    localhost:${{ inputs.localRegistryPort }}"
+        fi
         echo ""
         kubectl get nodes 2>/dev/null || true
         echo ""

--- a/action.yml
+++ b/action.yml
@@ -510,6 +510,12 @@ runs:
           exit 1
         fi
 
+    - name: Warn about Minikube multi-control-plane limitation
+      if: ${{ inputs.clusterProvider == 'minikube' && inputs.numControlPlaneNodes > 1 }}
+      shell: bash
+      run: |
+        echo "::warning::Minikube does not support true multi-control-plane HA. Setting numControlPlaneNodes > 1 creates additional generic nodes, not actual control planes."
+
     - name: Validate number of worker nodes
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -745,7 +745,7 @@ runs:
           "${{ inputs.apiServerAddress }}" \
           "${{ inputs.clusterName }}"
 
-    - name: Bootstrap the runner with kubectl and oc clients
+    - name: Bootstrap the runner with kubectl client
       if: ${{ inputs.dryRun != 'true' }}
       shell: bash
       run: |
@@ -862,7 +862,7 @@ runs:
       if: ${{ inputs.removeDefaultStorageClass == 'true' && inputs.dryRun != 'true' }}
       shell: bash
       run: |
-        oc delete storageclass standard --ignore-not-found
+        kubectl delete storageclass standard --ignore-not-found
 
     - name: Remove the control plane taint
       if: ${{ inputs.removeControlPlaneTaint == 'true' && inputs.dryRun != 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -853,6 +853,11 @@ runs:
         COMPONENT_TIMEOUT: ${{ inputs.componentTimeout }}
       run: ${{ github.action_path }}/scripts/install-thanos.sh ${{ inputs.thanosVersion }}
 
+    - name: Print monitoring access instructions
+      if: ${{ (inputs.installMetricsServer == 'true' || inputs.enableClusterMonitoring == 'true') && inputs.dryRun != 'true' }}
+      shell: bash
+      run: ${{ github.action_path }}/scripts/print-monitoring-info.sh "${{ inputs.installMetricsServer }}" "${{ inputs.enableClusterMonitoring }}"
+
     - name: Remove the default storage class
       if: ${{ inputs.removeDefaultStorageClass == 'true' && inputs.dryRun != 'true' }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: 'Quick K8s'
 description: 'Quickly deploy a k8s cluster on Github Actions hosted runners'
 branding:
-  icon: 'box'
+  icon: 'server'
   color: 'blue'
 inputs:
   apiServerPort:

--- a/scripts/bootstrap-docker.sh
+++ b/scripts/bootstrap-docker.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 # Configure Docker for Kubernetes (IPv6 support and file system limits)
 # Note: Docker storage relocation is handled by quick-cleanup action
 
+echo "::group::Configuring Docker for Kubernetes"
+trap 'echo "::endgroup::"' EXIT
+
 for cmd in curl tar jq; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "Error: $cmd is not installed." >&2

--- a/scripts/check-github-status.sh
+++ b/scripts/check-github-status.sh
@@ -32,6 +32,9 @@ check_affected_components() {
   fi
 }
 
+echo "::group::Checking GitHub status"
+trap 'echo "::endgroup::"' EXIT
+
 echo "🔍 Checking GitHub service status..."
 
 # Fetch overall status

--- a/scripts/diagnose-failure.sh
+++ b/scripts/diagnose-failure.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Sourceable utility that diagnoses common Kubernetes component installation
+# failures and prints actionable GitHub Actions error annotations.
+#
+# Usage:
+#   source "$(dirname "$0")/diagnose-failure.sh"
+#   output=$(kubectl apply -f manifest.yaml 2>&1) || diagnose_failure "Calico" "$output"
+
+diagnose_failure() {
+  local component="$1"
+  local output="$2"
+  local matched=false
+
+  # Disk space exhaustion
+  if echo "$output" | grep -qiE "no space left on device|disk pressure|DiskPressure"; then
+    echo "::error::${component} installation failed: disk space exhausted. Enable disk cleanup with quick-cleanup or use a larger runner."
+    matched=true
+  fi
+
+  # OOM / memory pressure
+  if echo "$output" | grep -qiE "OOMKill|oom-kill|Cannot allocate memory|MemoryPressure|memory pressure"; then
+    echo "::error::${component} installation failed: out of memory. Reduce resource requests, enable swap, or use a larger runner."
+    matched=true
+  fi
+
+  # Timeout / deadline exceeded
+  if echo "$output" | grep -qiE "timeout|timed out|deadline exceeded|context deadline exceeded"; then
+    echo "::error::${component} installation timed out. Try increasing COMPONENT_TIMEOUT (current: ${COMPONENT_TIMEOUT:-300}s) or check cluster health with 'kubectl get nodes' and 'kubectl get pods -A'."
+    matched=true
+  fi
+
+  # Image pull failures
+  if echo "$output" | grep -qiE "ImagePullBackOff|ErrImagePull|image pull|failed to pull image|manifest unknown"; then
+    echo "::error::${component} installation failed: unable to pull container image. Check that the version exists, your network allows registry access, and no rate limits apply."
+    matched=true
+  fi
+
+  # CrashLoopBackOff
+  if echo "$output" | grep -qiE "CrashLoopBackOff|crash loop"; then
+    echo "::error::${component} pods are crash-looping. Check pod logs with 'kubectl logs -n <namespace> <pod>' and events with 'kubectl describe pod'. This may indicate version incompatibility or missing prerequisites."
+    matched=true
+  fi
+
+  # Network / connectivity issues
+  if echo "$output" | grep -qiE "connection refused|connection reset|no route to host|network is unreachable|dial tcp.*timeout|i/o timeout"; then
+    echo "::error::${component} installation failed: network connectivity issue. Verify the cluster network is healthy and external URLs are reachable."
+    matched=true
+  fi
+
+  # DNS resolution failures
+  if echo "$output" | grep -qiE "no such host|could not resolve|lookup.*server misbehaving"; then
+    echo "::error::${component} installation failed: DNS resolution error. Check that cluster DNS (CoreDNS) is running and the runner has network access."
+    matched=true
+  fi
+
+  # API version / compatibility issues
+  if echo "$output" | grep -qiE "no matches for kind|the server doesn.t have a resource type|unable to recognize|unsupported value|is invalid:.*compilation failed"; then
+    echo "::error::${component} installation failed: Kubernetes API incompatibility. The ${component} version may not be compatible with your cluster's Kubernetes version. Try a different ${component} version."
+    matched=true
+  fi
+
+  # RBAC / permission issues
+  if echo "$output" | grep -qiE "forbidden|Forbidden|RBAC|unauthorized|cannot create|cannot patch"; then
+    echo "::error::${component} installation failed: insufficient permissions. Ensure the kubeconfig has cluster-admin privileges."
+    matched=true
+  fi
+
+  # Generic fallback
+  if [ "$matched" = false ]; then
+    echo "::error::${component} installation failed. Review the error output above. Common causes: resource exhaustion, version incompatibility, or network issues."
+  fi
+}
+
+# Collects pod status from a namespace to add context to failure diagnostics.
+# Call after a kubectl wait failure to show what went wrong.
+dump_pod_status() {
+  local namespace="$1"
+  local component="${2:-}"
+
+  echo "--- ${component:+$component }Pod status in namespace ${namespace} ---"
+  kubectl get pods -n "$namespace" -o wide 2>/dev/null || true
+  # Show events for non-running pods
+  local problem_pods
+  problem_pods=$(kubectl get pods -n "$namespace" --no-headers 2>/dev/null \
+    | awk '$3 != "Running" && $3 != "Completed" {print $1}') || true
+  for pod in $problem_pods; do
+    echo "--- Events for pod ${pod} ---"
+    kubectl describe pod -n "$namespace" "$pod" 2>/dev/null | tail -20 || true
+  done
+  echo "---"
+}

--- a/scripts/install-calico.sh
+++ b/scripts/install-calico.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 CALICO_VERSION="${1:?Usage: $0 <calico-version>}"
 
+echo "::group::Installing Calico CNI $CALICO_VERSION"
+trap 'echo "::endgroup::"' EXIT
+
 echo "Installing Calico CNI version $CALICO_VERSION..."
 
 if ! command -v kubectl >/dev/null 2>&1; then

--- a/scripts/install-calico.sh
+++ b/scripts/install-calico.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 CALICO_VERSION="${1:?Usage: $0 <calico-version>}"
 
+# shellcheck source=diagnose-failure.sh
+source "$(dirname "$0")/diagnose-failure.sh"
+
 echo "Installing Calico CNI version $CALICO_VERSION..."
 
 if ! command -v kubectl >/dev/null 2>&1; then
@@ -37,7 +40,7 @@ while [ $attempt -le $max_attempts ]; do
   fi
 
   if [ $attempt -eq $max_attempts ]; then
-    echo "Calico installation failed after $max_attempts attempts"
+    diagnose_failure "Calico" "$output"
     exit $exit_code
   fi
 

--- a/scripts/install-cert-manager.sh
+++ b/scripts/install-cert-manager.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 CERT_MANAGER_VERSION="${1:-v1.19.3}"
 TIMEOUT="${COMPONENT_TIMEOUT:-300}"
 
+echo "::group::Installing cert-manager $CERT_MANAGER_VERSION"
+trap 'echo "::endgroup::"' EXIT
+
 echo "Installing cert-manager version $CERT_MANAGER_VERSION"
 
 # Verify required tools are available

--- a/scripts/install-cert-manager.sh
+++ b/scripts/install-cert-manager.sh
@@ -29,3 +29,21 @@ kubectl wait --for=condition=ready pod --all --namespace=cert-manager --timeout=
 
 kubectl get pods -n cert-manager
 echo "cert-manager $CERT_MANAGER_VERSION installed successfully!"
+
+echo "Creating self-signed ClusterIssuer for TLS testing..."
+kubectl apply -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-issuer
+spec:
+  selfSigned: {}
+EOF
+
+echo "Waiting for ClusterIssuer to be ready..."
+kubectl wait --for=condition=Ready clusterissuer/selfsigned-issuer --timeout=60s || {
+  echo "Warning: ClusterIssuer may not be ready yet. Current status:"
+  kubectl get clusterissuer selfsigned-issuer -o wide 2>/dev/null || true
+}
+
+echo "Self-signed ClusterIssuer configured successfully!"

--- a/scripts/install-cert-manager.sh
+++ b/scripts/install-cert-manager.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 CERT_MANAGER_VERSION="${1:-v1.19.3}"
 TIMEOUT="${COMPONENT_TIMEOUT:-300}"
 
+# shellcheck source=diagnose-failure.sh
+source "$(dirname "$0")/diagnose-failure.sh"
+
 echo "Installing cert-manager version $CERT_MANAGER_VERSION"
 
 # Verify required tools are available
@@ -17,15 +20,21 @@ done
 MANIFEST_URL="https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml"
 echo "Downloading cert-manager manifest from: $MANIFEST_URL"
 
-if ! kubectl apply --timeout=5m -f "$MANIFEST_URL"; then
-  echo "Error: Failed to apply cert-manager manifest" >&2
+apply_output=$(kubectl apply --timeout=5m -f "$MANIFEST_URL" 2>&1) || {
+  echo "$apply_output"
+  diagnose_failure "cert-manager" "$apply_output"
   exit 1
-fi
+}
+echo "$apply_output"
 
 echo "Waiting for cert-manager pods to be ready..."
-kubectl wait --for=condition=ready pod --all --namespace=cert-manager --timeout="${TIMEOUT}s" || {
-  echo "Warning: Some cert-manager pods may not be ready yet. Continuing..."
+wait_output=$(kubectl wait --for=condition=ready pod --all --namespace=cert-manager --timeout="${TIMEOUT}s" 2>&1) || {
+  echo "$wait_output"
+  dump_pod_status "cert-manager" "cert-manager"
+  diagnose_failure "cert-manager" "$wait_output"
+  exit 1
 }
+echo "$wait_output"
 
 kubectl get pods -n cert-manager
 echo "cert-manager $CERT_MANAGER_VERSION installed successfully!"

--- a/scripts/install-ingress-nginx.sh
+++ b/scripts/install-ingress-nginx.sh
@@ -5,6 +5,9 @@ INGRESS_NGINX_VERSION="${1:-v1.14.3}"
 CLUSTER_PROVIDER="${2:-kind}"
 TIMEOUT="${COMPONENT_TIMEOUT:-300}"
 
+echo "::group::Installing ingress-nginx $INGRESS_NGINX_VERSION"
+trap 'echo "::endgroup::"' EXIT
+
 echo "Installing ingress-nginx version $INGRESS_NGINX_VERSION for $CLUSTER_PROVIDER"
 
 # Verify required tools are available

--- a/scripts/install-ingress-nginx.sh
+++ b/scripts/install-ingress-nginx.sh
@@ -5,6 +5,9 @@ INGRESS_NGINX_VERSION="${1:-v1.14.3}"
 CLUSTER_PROVIDER="${2:-kind}"
 TIMEOUT="${COMPONENT_TIMEOUT:-300}"
 
+# shellcheck source=diagnose-failure.sh
+source "$(dirname "$0")/diagnose-failure.sh"
+
 echo "Installing ingress-nginx version $INGRESS_NGINX_VERSION for $CLUSTER_PROVIDER"
 
 # Verify required tools are available
@@ -26,18 +29,24 @@ fi
 
 echo "Downloading ingress-nginx manifest from: $MANIFEST_URL"
 
-if ! kubectl apply --timeout=5m -f "$MANIFEST_URL"; then
-  echo "Error: Failed to apply ingress-nginx manifest" >&2
+apply_output=$(kubectl apply --timeout=5m -f "$MANIFEST_URL" 2>&1) || {
+  echo "$apply_output"
+  diagnose_failure "ingress-nginx" "$apply_output"
   exit 1
-fi
+}
+echo "$apply_output"
 
 echo "Waiting for ingress-nginx controller to be ready..."
-kubectl wait --namespace ingress-nginx \
+wait_output=$(kubectl wait --namespace ingress-nginx \
   --for=condition=ready pod \
   --selector=app.kubernetes.io/component=controller \
-  --timeout="${TIMEOUT}s" || {
-  echo "Warning: ingress-nginx controller may not be ready yet. Continuing..."
+  --timeout="${TIMEOUT}s" 2>&1) || {
+  echo "$wait_output"
+  dump_pod_status "ingress-nginx" "ingress-nginx"
+  diagnose_failure "ingress-nginx" "$wait_output"
+  exit 1
 }
+echo "$wait_output"
 
 kubectl get pods -n ingress-nginx
 echo "ingress-nginx $INGRESS_NGINX_VERSION installed successfully!"

--- a/scripts/install-istio.sh
+++ b/scripts/install-istio.sh
@@ -5,6 +5,9 @@ ISTIO_VERSION="${1:-1.28.1}"
 ISTIO_PROFILE="${2:-minimal}"
 TIMEOUT="${COMPONENT_TIMEOUT:-300}"
 
+echo "::group::Installing Istio $ISTIO_VERSION"
+trap 'echo "::endgroup::"' EXIT
+
 echo "Installing Istio version $ISTIO_VERSION with profile $ISTIO_PROFILE"
 
 # Check for required commands

--- a/scripts/install-istio.sh
+++ b/scripts/install-istio.sh
@@ -5,6 +5,9 @@ ISTIO_VERSION="${1:-1.28.1}"
 ISTIO_PROFILE="${2:-minimal}"
 TIMEOUT="${COMPONENT_TIMEOUT:-300}"
 
+# shellcheck source=diagnose-failure.sh
+source "$(dirname "$0")/diagnose-failure.sh"
+
 echo "Installing Istio version $ISTIO_VERSION with profile $ISTIO_PROFILE"
 
 # Check for required commands
@@ -26,10 +29,7 @@ ISTIO_URL="https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/ist
 echo "Downloading Istio from: $ISTIO_URL"
 
 if ! curl -fSL --retry 3 --retry-delay 5 --retry-all-errors "$ISTIO_URL" -o istio.tar.gz; then
-  echo "Error: Failed to download Istio from $ISTIO_URL after multiple attempts" >&2
-  echo "This may indicate:" >&2
-  echo "  1. Network connectivity issues" >&2
-  echo "  2. Istio version $ISTIO_VERSION may not be available for $OS-$ARCH" >&2
+  echo "::error::Failed to download Istio from $ISTIO_URL after multiple attempts. Check network connectivity or verify Istio version $ISTIO_VERSION is available for $OS-$ARCH."
   rm -f istio.tar.gz
   exit 1
 fi
@@ -61,16 +61,25 @@ istioctl version --remote=false
 
 # Install Istio using the specified profile
 echo "Installing Istio with profile: $ISTIO_PROFILE"
-istioctl install --set profile="$ISTIO_PROFILE" -y
+install_output=$(istioctl install --set profile="$ISTIO_PROFILE" -y 2>&1) || {
+  echo "$install_output"
+  diagnose_failure "Istio" "$install_output"
+  exit 1
+}
+echo "$install_output"
 
 # Wait for Istio pods to be ready
 echo "Waiting for Istio control plane pods to be ready..."
-kubectl wait --for=condition=ready pod \
+wait_output=$(kubectl wait --for=condition=ready pod \
   --all \
   --namespace=istio-system \
-  --timeout="${TIMEOUT}s" || {
-    echo "Warning: Some Istio pods may not be ready yet. Continuing..."
-  }
+  --timeout="${TIMEOUT}s" 2>&1) || {
+  echo "$wait_output"
+  dump_pod_status "istio-system" "Istio"
+  diagnose_failure "Istio" "$wait_output"
+  exit 1
+}
+echo "$wait_output"
 
 # Show Istio status
 echo "Istio installation complete!"
@@ -81,4 +90,3 @@ echo "Cleaning up installation files..."
 rm -rf istio.tar.gz "$ISTIO_DIR"
 
 echo "Istio $ISTIO_VERSION with profile $ISTIO_PROFILE installed successfully!"
-

--- a/scripts/install-kind.sh
+++ b/scripts/install-kind.sh
@@ -15,6 +15,9 @@ if [ -z "$VERSION" ] || [ -z "$OS" ] || [ -z "$ARCH" ]; then
   exit 1
 fi
 
+echo "::group::Installing KinD $VERSION"
+trap 'echo "::endgroup::"' EXIT
+
 # shellcheck source=map-platform.sh
 source "$(dirname "$0")/map-platform.sh"
 OS=$(map_os "$OS")

--- a/scripts/install-metrics-server.sh
+++ b/scripts/install-metrics-server.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 METRICS_SERVER_VERSION="${1:-v0.8.1}"
 TIMEOUT="${COMPONENT_TIMEOUT:-300}"
 
+echo "::group::Installing metrics-server $METRICS_SERVER_VERSION"
+trap 'echo "::endgroup::"' EXIT
+
 echo "Installing metrics-server version $METRICS_SERVER_VERSION"
 
 # Verify required tools are available

--- a/scripts/install-metrics-server.sh
+++ b/scripts/install-metrics-server.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 METRICS_SERVER_VERSION="${1:-v0.8.1}"
 TIMEOUT="${COMPONENT_TIMEOUT:-300}"
 
+# shellcheck source=diagnose-failure.sh
+source "$(dirname "$0")/diagnose-failure.sh"
+
 echo "Installing metrics-server version $METRICS_SERVER_VERSION"
 
 # Verify required tools are available
@@ -19,20 +22,26 @@ echo "Downloading metrics-server manifest from: $MANIFEST_URL"
 
 # Download and patch for local clusters (add --kubelet-insecure-tls)
 # This is required for KinD/Minikube where kubelet uses self-signed certs
-if ! curl -sL "$MANIFEST_URL" | \
+apply_output=$(curl -sL "$MANIFEST_URL" | \
   sed '/args:/a\        - --kubelet-insecure-tls' | \
-  kubectl apply --timeout=5m -f -; then
-  echo "Error: Failed to apply metrics-server manifest" >&2
+  kubectl apply --timeout=5m -f - 2>&1) || {
+  echo "$apply_output"
+  diagnose_failure "metrics-server" "$apply_output"
   exit 1
-fi
+}
+echo "$apply_output"
 
 echo "Waiting for metrics-server to be ready..."
-kubectl wait --namespace kube-system \
+wait_output=$(kubectl wait --namespace kube-system \
   --for=condition=ready pod \
   --selector=k8s-app=metrics-server \
-  --timeout="${TIMEOUT}s" || {
-  echo "Warning: metrics-server may not be ready yet. Continuing..."
+  --timeout="${TIMEOUT}s" 2>&1) || {
+  echo "$wait_output"
+  dump_pod_status "kube-system" "metrics-server"
+  diagnose_failure "metrics-server" "$wait_output"
+  exit 1
 }
+echo "$wait_output"
 
 kubectl get pods -n kube-system -l k8s-app=metrics-server
 echo "metrics-server $METRICS_SERVER_VERSION installed successfully!"

--- a/scripts/install-minikube.sh
+++ b/scripts/install-minikube.sh
@@ -15,6 +15,9 @@ if [ -z "$VERSION" ] || [ -z "$OS" ] || [ -z "$ARCH" ]; then
   exit 1
 fi
 
+echo "::group::Installing Minikube $VERSION"
+trap 'echo "::endgroup::"' EXIT
+
 # shellcheck source=map-platform.sh
 source "$(dirname "$0")/map-platform.sh"
 OS=$(map_os "$OS")

--- a/scripts/install-oc-tools.sh
+++ b/scripts/install-oc-tools.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+echo "::group::Installing OpenShift CLI tools"
+trap 'echo "::endgroup::"' EXIT
+
 for cmd in curl tar; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "Error: $cmd is not installed." >&2

--- a/scripts/install-olm.sh
+++ b/scripts/install-olm.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 
 OLM_VERSION="v0.45.0"
 TIMEOUT="${COMPONENT_TIMEOUT:-300}"
+
+# shellcheck source=diagnose-failure.sh
+source "$(dirname "$0")/diagnose-failure.sh"
+
 echo "Installing OLM version $OLM_VERSION"
 
 for cmd in curl kubectl; do
@@ -15,18 +19,33 @@ done
 if ! curl -fSL --retry 3 --retry-delay 5 --retry-all-errors \
   "https://github.com/operator-framework/operator-lifecycle-manager/releases/download/$OLM_VERSION/install.sh" \
   -o install.sh; then
-  echo "Error: Failed to download OLM install script for version $OLM_VERSION" >&2
+  echo "::error::Failed to download OLM install script for version $OLM_VERSION. Check network connectivity or verify the OLM version exists."
   exit 1
 fi
 
 chmod +x install.sh
-./install.sh "$OLM_VERSION"
-rm install.sh
+install_output=$(./install.sh "$OLM_VERSION" 2>&1) || {
+  echo "$install_output"
+  diagnose_failure "OLM" "$install_output"
+  rm -f install.sh
+  exit 1
+}
+echo "$install_output"
+rm -f install.sh
 
 echo "Waiting for OLM pods to be ready..."
-kubectl wait --for=condition=ready pod --all --namespace=olm --timeout="${TIMEOUT}s" || {
-  echo "Warning: Some OLM pods may not be ready yet. Continuing..."
+wait_output=$(kubectl wait --for=condition=ready pod --all --namespace=olm --timeout="${TIMEOUT}s" 2>&1) || {
+  echo "$wait_output"
+  dump_pod_status "olm" "OLM"
+  diagnose_failure "OLM" "$wait_output"
+  exit 1
 }
-kubectl wait --for=condition=ready pod --all --namespace=operators --timeout="${TIMEOUT}s" || {
-  echo "Warning: Some operator pods may not be ready yet. Continuing..."
+echo "$wait_output"
+
+wait_output=$(kubectl wait --for=condition=ready pod --all --namespace=operators --timeout="${TIMEOUT}s" 2>&1) || {
+  echo "$wait_output"
+  dump_pod_status "operators" "OLM operators"
+  diagnose_failure "OLM" "$wait_output"
+  exit 1
 }
+echo "$wait_output"

--- a/scripts/install-olm.sh
+++ b/scripts/install-olm.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 
 OLM_VERSION="v0.45.0"
 TIMEOUT="${COMPONENT_TIMEOUT:-300}"
+
+echo "::group::Installing OLM $OLM_VERSION"
+trap 'echo "::endgroup::"' EXIT
+
 echo "Installing OLM version $OLM_VERSION"
 
 for cmd in curl kubectl; do

--- a/scripts/install-operator-sdk.sh
+++ b/scripts/install-operator-sdk.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 OPERATOR_SDK_VERSION="${1:?operator-sdk version argument is required}"
 
+echo "::group::Installing operator-sdk $OPERATOR_SDK_VERSION"
+trap 'echo "::endgroup::"' EXIT
+
 echo "Installing operator-sdk version $OPERATOR_SDK_VERSION"
 
 if ! command -v curl >/dev/null 2>&1; then

--- a/scripts/install-prometheus.sh
+++ b/scripts/install-prometheus.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 KUBE_PROMETHEUS_VERSION="${1:-v0.14.0}"
 TIMEOUT="${COMPONENT_TIMEOUT:-300}"
 
+# shellcheck source=diagnose-failure.sh
+source "$(dirname "$0")/diagnose-failure.sh"
+
 echo "Installing kube-prometheus version $KUBE_PROMETHEUS_VERSION"
 
 # Verify required tools are available
@@ -24,7 +27,7 @@ trap cleanup EXIT
 echo "Downloading kube-prometheus from: $TARBALL_URL"
 
 if ! curl -fSL --retry 3 --retry-delay 5 --retry-all-errors "$TARBALL_URL" -o /tmp/kube-prometheus.tar.gz; then
-  echo "Error: Failed to download kube-prometheus" >&2
+  echo "::error::Failed to download kube-prometheus from $TARBALL_URL. Check network connectivity or verify the version exists."
   exit 1
 fi
 
@@ -41,10 +44,12 @@ grep -rl 'memory:\|cpu:' "${KUBE_PROMETHEUS_DIR}/manifests/" --include="*.yaml" 
   -e 's/cpu: "2"/cpu: 200m/g'
 
 echo "Applying kube-prometheus setup manifests (CRDs, namespace)..."
-if ! kubectl apply --server-side --timeout=5m -f "${KUBE_PROMETHEUS_DIR}/manifests/setup/"; then
-  echo "Error: Failed to apply kube-prometheus setup manifests" >&2
+setup_output=$(kubectl apply --server-side --timeout=5m -f "${KUBE_PROMETHEUS_DIR}/manifests/setup/" 2>&1) || {
+  echo "$setup_output"
+  diagnose_failure "kube-prometheus" "$setup_output"
   exit 1
-fi
+}
+echo "$setup_output"
 
 echo "Waiting for CRDs to be established..."
 kubectl wait --for condition=Established --all CustomResourceDefinition --timeout=120s
@@ -52,15 +57,21 @@ kubectl wait --for condition=Established --all CustomResourceDefinition --timeou
 # Apply twice — first pass may fail on CRD-to-CR ordering races
 echo "Applying kube-prometheus manifests..."
 kubectl apply --timeout=5m -f "${KUBE_PROMETHEUS_DIR}/manifests/" 2>&1 || true
-if ! kubectl apply --timeout=5m -f "${KUBE_PROMETHEUS_DIR}/manifests/"; then
-  echo "Error: Failed to apply kube-prometheus manifests" >&2
+apply_output=$(kubectl apply --timeout=5m -f "${KUBE_PROMETHEUS_DIR}/manifests/" 2>&1) || {
+  echo "$apply_output"
+  diagnose_failure "kube-prometheus" "$apply_output"
   exit 1
-fi
+}
+echo "$apply_output"
 
 echo "Waiting for monitoring pods to be ready..."
-kubectl wait --for=condition=ready pod --all --namespace=monitoring --timeout="${TIMEOUT}s" || {
-  echo "Warning: Some monitoring pods may not be ready yet. Continuing..."
+wait_output=$(kubectl wait --for=condition=ready pod --all --namespace=monitoring --timeout="${TIMEOUT}s" 2>&1) || {
+  echo "$wait_output"
+  dump_pod_status "monitoring" "kube-prometheus"
+  diagnose_failure "kube-prometheus" "$wait_output"
+  exit 1
 }
+echo "$wait_output"
 
 kubectl get pods -n monitoring
 echo "kube-prometheus $KUBE_PROMETHEUS_VERSION installed successfully!"

--- a/scripts/install-prometheus.sh
+++ b/scripts/install-prometheus.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 KUBE_PROMETHEUS_VERSION="${1:-v0.14.0}"
 TIMEOUT="${COMPONENT_TIMEOUT:-300}"
 
-echo "Installing kube-prometheus version $KUBE_PROMETHEUS_VERSION"
+echo "::group::Installing kube-prometheus $KUBE_PROMETHEUS_VERSION"
 
 # Verify required tools are available
 for cmd in curl kubectl tar; do
@@ -19,7 +19,7 @@ TARBALL_URL="https://github.com/prometheus-operator/kube-prometheus/archive/refs
 KUBE_PROMETHEUS_DIR="/tmp/kube-prometheus-${VERSION_NO_V}"
 
 cleanup() { rm -rf /tmp/kube-prometheus.tar.gz "${KUBE_PROMETHEUS_DIR}"; }
-trap cleanup EXIT
+trap 'cleanup; echo "::endgroup::"' EXIT
 
 echo "Downloading kube-prometheus from: $TARBALL_URL"
 

--- a/scripts/install-thanos.sh
+++ b/scripts/install-thanos.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 THANOS_VERSION="${1:-v0.37.2}"
 TIMEOUT="${COMPONENT_TIMEOUT:-300}"
 
+# shellcheck source=diagnose-failure.sh
+source "$(dirname "$0")/diagnose-failure.sh"
+
 echo "Installing Thanos version $THANOS_VERSION"
 
 # Verify required tools are available
@@ -14,7 +17,7 @@ fi
 
 # Verify Prometheus is running (Thanos requires it)
 if ! kubectl get namespace monitoring >/dev/null 2>&1; then
-  echo "Error: monitoring namespace not found. Prometheus must be installed first." >&2
+  echo "::error::Thanos installation failed: monitoring namespace not found. Prometheus (kube-prometheus) must be installed first. Set installPrometheus: true in your action inputs."
   exit 1
 fi
 
@@ -25,7 +28,7 @@ kubectl delete networkpolicies --all -n monitoring 2>/dev/null || true
 
 # Patch the Prometheus CR to add Thanos sidecar via the Prometheus Operator's built-in spec.thanos field
 echo "Configuring Thanos sidecar on Prometheus..."
-kubectl -n monitoring patch prometheus k8s --type=merge -p "{
+patch_output=$(kubectl -n monitoring patch prometheus k8s --type=merge -p "{
   \"spec\": {
     \"thanos\": {
       \"version\": \"${THANOS_VERSION}\",
@@ -41,11 +44,16 @@ kubectl -n monitoring patch prometheus k8s --type=merge -p "{
       }
     }
   }
-}"
+}" 2>&1) || {
+  echo "$patch_output"
+  diagnose_failure "Thanos" "$patch_output"
+  exit 1
+}
+echo "$patch_output"
 
 # Deploy Thanos Query and headless sidecar service
 echo "Deploying Thanos Query and services..."
-cat <<EOF | kubectl apply --timeout=5m -f -
+apply_output=$(cat <<EOF | kubectl apply --timeout=5m -f - 2>&1
 apiVersion: v1
 kind: Service
 metadata:
@@ -117,16 +125,30 @@ spec:
       port: 10901
       targetPort: grpc
 EOF
+) || {
+  echo "$apply_output"
+  diagnose_failure "Thanos" "$apply_output"
+  exit 1
+}
+echo "$apply_output"
 
 echo "Waiting for Prometheus to restart with Thanos sidecar..."
-kubectl rollout status statefulset/prometheus-k8s -n monitoring --timeout="${TIMEOUT}s" || {
-  echo "Warning: Prometheus may still be restarting. Continuing..."
+rollout_output=$(kubectl rollout status statefulset/prometheus-k8s -n monitoring --timeout="${TIMEOUT}s" 2>&1) || {
+  echo "$rollout_output"
+  dump_pod_status "monitoring" "Thanos/Prometheus"
+  diagnose_failure "Thanos" "$rollout_output"
+  exit 1
 }
+echo "$rollout_output"
 
 echo "Waiting for Thanos Query to be ready..."
-kubectl rollout status deployment/thanos-query -n monitoring --timeout="${TIMEOUT}s" || {
-  echo "Warning: Thanos Query may not be ready yet. Continuing..."
+rollout_output=$(kubectl rollout status deployment/thanos-query -n monitoring --timeout="${TIMEOUT}s" 2>&1) || {
+  echo "$rollout_output"
+  dump_pod_status "monitoring" "Thanos Query"
+  diagnose_failure "Thanos" "$rollout_output"
+  exit 1
 }
+echo "$rollout_output"
 
 kubectl get pods -n monitoring
 echo "Thanos $THANOS_VERSION installed successfully!"

--- a/scripts/install-thanos.sh
+++ b/scripts/install-thanos.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 THANOS_VERSION="${1:-v0.37.2}"
 TIMEOUT="${COMPONENT_TIMEOUT:-300}"
 
+echo "::group::Installing Thanos $THANOS_VERSION"
+trap 'echo "::endgroup::"' EXIT
+
 echo "Installing Thanos version $THANOS_VERSION"
 
 # Verify required tools are available

--- a/scripts/label-worker-nodes.sh
+++ b/scripts/label-worker-nodes.sh
@@ -8,6 +8,9 @@ set -euo pipefail
 EXPECTED_WORKERS=${1:?"Usage: $0 <expected-worker-count> <comma-separated-labels>"}
 LABELS_CSV=${2:?"Usage: $0 <expected-worker-count> <comma-separated-labels>"}
 
+echo "::group::Labeling worker nodes"
+trap 'echo "::endgroup::"' EXIT
+
 if ! command -v kubectl >/dev/null 2>&1; then
   echo "Error: kubectl is not installed." >&2
   exit 1

--- a/scripts/pre-cluster-optimization.sh
+++ b/scripts/pre-cluster-optimization.sh
@@ -6,6 +6,9 @@
 
 set -euo pipefail
 
+echo "::group::Pre-cluster optimization"
+trap 'echo "::endgroup::"' EXIT
+
 echo "=============================================="
 echo "⚡ FINAL PRE-CLUSTER OPTIMIZATION"
 echo "=============================================="

--- a/scripts/print-monitoring-info.sh
+++ b/scripts/print-monitoring-info.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Print access instructions for installed monitoring components.
+# Arguments:
+#   $1 - "true" if metrics-server is installed
+#   $2 - "true" if cluster monitoring (kube-prometheus + Thanos) is installed
+
+METRICS_SERVER="${1:-false}"
+CLUSTER_MONITORING="${2:-false}"
+
+if [ "$METRICS_SERVER" != "true" ] && [ "$CLUSTER_MONITORING" != "true" ]; then
+  exit 0
+fi
+
+echo ""
+echo "======================================"
+echo "  Monitoring Access Instructions"
+echo "======================================"
+
+if [ "$METRICS_SERVER" = "true" ]; then
+  echo ""
+  echo "--- metrics-server ---"
+  echo ""
+  echo "  metrics-server provides resource usage data (no web UI)."
+  echo ""
+  echo "  Query resource usage:"
+  echo "    kubectl top nodes"
+  echo "    kubectl top pods -A"
+  echo "    kubectl top pods -n <namespace>"
+  echo ""
+  echo "  Raw metrics API:"
+  echo "    kubectl get --raw /apis/metrics.k8s.io/v1beta1/nodes"
+  echo "    kubectl get --raw /apis/metrics.k8s.io/v1beta1/pods"
+fi
+
+if [ "$CLUSTER_MONITORING" = "true" ]; then
+  echo ""
+  echo "--- Prometheus ---"
+  echo ""
+  echo "  Namespace: monitoring"
+  echo "  Service:   prometheus-k8s"
+  echo "  Port:      9090"
+  echo ""
+  echo "  Port-forward:"
+  echo "    kubectl port-forward -n monitoring svc/prometheus-k8s 9090:9090"
+  echo "  Then open: http://localhost:9090"
+  echo ""
+  echo "--- Alertmanager ---"
+  echo ""
+  echo "  Namespace: monitoring"
+  echo "  Service:   alertmanager-main"
+  echo "  Port:      9093"
+  echo ""
+  echo "  Port-forward:"
+  echo "    kubectl port-forward -n monitoring svc/alertmanager-main 9093:9093"
+  echo "  Then open: http://localhost:9093"
+  echo ""
+  echo "--- Grafana ---"
+  echo ""
+  echo "  Namespace: monitoring"
+  echo "  Service:   grafana"
+  echo "  Port:      3000"
+  echo ""
+  echo "  Port-forward:"
+  echo "    kubectl port-forward -n monitoring svc/grafana 3000:3000"
+  echo "  Then open: http://localhost:3000"
+  echo "  Default credentials: admin / admin"
+  echo ""
+  echo "--- Thanos Query ---"
+  echo ""
+  echo "  Namespace: monitoring"
+  echo "  Service:   thanos-query"
+  echo "  Port:      9090"
+  echo ""
+  echo "  Port-forward:"
+  echo "    kubectl port-forward -n monitoring svc/thanos-query 10902:9090"
+  echo "  Then open: http://localhost:10902"
+  echo ""
+  echo "--- List all monitoring services ---"
+  echo ""
+  echo "  kubectl get svc -n monitoring"
+fi
+
+echo ""
+echo "======================================"

--- a/scripts/pull-kind-image.sh
+++ b/scripts/pull-kind-image.sh
@@ -13,6 +13,9 @@ if [ -z "$IMAGE" ]; then
   exit 1
 fi
 
+echo "::group::Pre-pulling KinD node image"
+trap 'echo "::endgroup::"' EXIT
+
 max_attempts=3
 delay=30
 

--- a/scripts/remove-control-plane-taint.sh
+++ b/scripts/remove-control-plane-taint.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 # Script to remove the control plane taint from the control-plane nodes
 
+echo "::group::Removing control-plane taint"
+trap 'echo "::endgroup::"' EXIT
+
 # Command precheck
 if ! command -v kubectl >/dev/null 2>&1; then
   echo "Error: kubectl is not installed." >&2

--- a/scripts/setup-local-registry.sh
+++ b/scripts/setup-local-registry.sh
@@ -10,6 +10,9 @@ CLUSTER_PROVIDER="${2:-kind}"
 CLUSTER_NAME="${3:-kind}"
 REGISTRY_NAME="quick-k8s-registry"
 
+echo "::group::Setting up local Docker registry on port ${REGISTRY_PORT}"
+trap 'echo "::endgroup::"' EXIT
+
 echo "Setting up local Docker registry on port ${REGISTRY_PORT}..."
 
 # Check if registry already exists

--- a/scripts/start-minikube.sh
+++ b/scripts/start-minikube.sh
@@ -20,6 +20,9 @@ if [ -z "$NODE_IMAGE" ]; then
   exit 1
 fi
 
+echo "::group::Starting Minikube cluster"
+trap 'echo "::endgroup::"' EXIT
+
 # Extract Kubernetes version from the defaultNodeImage
 # Format: 'kindest/node:v1.33.1@sha256:...' -> 'v1.33.1'
 K8S_VERSION=$(echo "$NODE_IMAGE" | sed -E 's/.*:([^@]+)@.*/\1/')

--- a/scripts/wait-for-pods.sh
+++ b/scripts/wait-for-pods.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+echo "::group::Waiting for pods to be ready"
+trap 'echo "::endgroup::"' EXIT
+
 if ! command -v kubectl >/dev/null 2>&1; then
   echo "Error: kubectl is not installed." >&2
   exit 1

--- a/scripts/wait-for-pods.sh
+++ b/scripts/wait-for-pods.sh
@@ -66,6 +66,16 @@ while true; do
     elapsed=$((elapsed + interval))
     if [ $elapsed -ge $timeout ]; then
       echo "Timeout reached: Not all pods are running or completed"
+      echo ""
+      echo "=== Pod State Dump (all namespaces) ==="
+      kubectl get pods -A
+      echo ""
+      echo "=== Describing non-Running pods ==="
+      kubectl get pods -A --no-headers | awk '$4 != "Running" && $4 != "Completed" && $4 != "Succeeded" {print $1, $2}' | while read -r ns pod; do
+        echo "--- Describing ${ns}/${pod} ---"
+        kubectl describe pod "$pod" -n "$ns"
+        echo ""
+      done
       exit 1
     fi
   fi


### PR DESCRIPTION
## Summary
- Wrap each script's output in GitHub Actions `::group::`/`::endgroup::` annotations so the Actions log becomes collapsible and easier to navigate
- Use an EXIT trap to ensure `::endgroup::` always fires, even on script failure
- Updated 21 scripts: all `install-*.sh` scripts plus `setup-local-registry.sh`, `pre-cluster-optimization.sh`, `start-minikube.sh`, `pull-kind-image.sh`, `bootstrap-docker.sh`, `label-worker-nodes.sh`, `wait-for-pods.sh`, `check-github-status.sh`, and `remove-control-plane-taint.sh`
- For `install-prometheus.sh` which already had an EXIT trap for cleanup, the existing trap was extended to also emit `::endgroup::`

## Test plan
- [ ] Verify shellcheck passes (done locally)
- [ ] CI matrix tests pass with no regressions
- [ ] Confirm log groups appear as collapsible sections in GitHub Actions UI

Closes #250