### PR TITLE
feat: Add SHA256 checksum verification for binary downloads

### DIFF
--- a/scripts/install-istio.sh
+++ b/scripts/install-istio.sh
@@ -23,6 +23,8 @@ done
 
 # shellcheck source=map-platform.sh
 source "$(dirname "$0")/map-platform.sh"
+# shellcheck source=verify-checksum.sh
+source "$(dirname "$0")/verify-checksum.sh"
 ARCH=$(map_arch "$(uname -m)")
 OS=$(map_os "$(uname -s)")
 
@@ -37,6 +39,15 @@ if ! curl -fSL --retry 3 --retry-delay 5 --retry-all-errors "$ISTIO_URL" -o isti
   exit 1
 fi
 echo "Istio download succeeded"
+
+# Verify SHA256 checksum
+ISTIO_TARBALL="istio-${ISTIO_VERSION}-${OS}-${ARCH}.tar.gz"
+CHECKSUM_URL="https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/${ISTIO_TARBALL}.sha256"
+if ! download_and_verify_checksum istio.tar.gz "$CHECKSUM_URL"; then
+  echo "::error::Istio tarball checksum verification failed - the download may be corrupted or tampered with"
+  rm -f istio.tar.gz
+  exit 1
+fi
 
 # Extract istioctl
 echo "Extracting istioctl..."

--- a/scripts/install-kind.sh
+++ b/scripts/install-kind.sh
@@ -20,6 +20,8 @@ trap 'echo "::endgroup::"' EXIT
 
 # shellcheck source=map-platform.sh
 source "$(dirname "$0")/map-platform.sh"
+# shellcheck source=verify-checksum.sh
+source "$(dirname "$0")/verify-checksum.sh"
 OS=$(map_os "$OS")
 ARCH=$(map_arch "$ARCH")
 
@@ -75,6 +77,14 @@ fi
 # Verify it's a binary, not HTML
 if file kind | grep -q "HTML"; then
   echo "ERROR: Downloaded file is HTML, not a binary"
+  exit 1
+fi
+
+# Verify SHA256 checksum
+CHECKSUM_URL="https://github.com/kubernetes-sigs/kind/releases/download/${VERSION}/kind-${PLATFORM}.sha256sum"
+if ! download_and_verify_checksum kind "$CHECKSUM_URL"; then
+  echo "::error::KinD binary checksum verification failed - the download may be corrupted or tampered with"
+  rm -f kind
   exit 1
 fi
 

--- a/scripts/install-minikube.sh
+++ b/scripts/install-minikube.sh
@@ -20,6 +20,8 @@ trap 'echo "::endgroup::"' EXIT
 
 # shellcheck source=map-platform.sh
 source "$(dirname "$0")/map-platform.sh"
+# shellcheck source=verify-checksum.sh
+source "$(dirname "$0")/verify-checksum.sh"
 OS=$(map_os "$OS")
 ARCH=$(map_arch "$ARCH")
 
@@ -59,6 +61,14 @@ if ! curl -fsSL -o minikube "${DOWNLOAD_URL}"; then
 fi
 
 echo "✅ Successfully downloaded Minikube binary"
+
+# Verify SHA256 checksum
+CHECKSUM_URL="https://github.com/kubernetes/minikube/releases/download/${VERSION}/minikube-${PLATFORM}.sha256"
+if ! download_and_verify_checksum minikube "$CHECKSUM_URL"; then
+  echo "::error::Minikube binary checksum verification failed - the download may be corrupted or tampered with"
+  rm -f minikube
+  exit 1
+fi
 
 # Install the binary
 chmod +x minikube

--- a/scripts/install-olm.sh
+++ b/scripts/install-olm.sh
@@ -26,6 +26,8 @@ if ! curl -fSL --retry 3 --retry-delay 5 --retry-all-errors \
   exit 1
 fi
 
+echo "::warning::Checksum verification skipped for OLM install script - no checksum published for install.sh"
+
 chmod +x install.sh
 install_output=$(./install.sh "$OLM_VERSION" 2>&1) || {
   echo "$install_output"

--- a/scripts/install-operator-sdk.sh
+++ b/scripts/install-operator-sdk.sh
@@ -15,6 +15,8 @@ fi
 
 # shellcheck source=map-platform.sh
 source "$(dirname "$0")/map-platform.sh"
+# shellcheck source=verify-checksum.sh
+source "$(dirname "$0")/verify-checksum.sh"
 ARCH=$(map_arch "$(uname -m)")
 OS=$(map_os "$(uname -s)")
 
@@ -23,6 +25,15 @@ DL_URL="https://github.com/operator-framework/operator-sdk/releases/download/${O
 echo "Downloading operator-sdk from: $DL_URL"
 if ! curl -fL --retry 3 --retry-delay 5 -o /tmp/operator-sdk "$DL_URL"; then
   echo "Error: Failed to download operator-sdk" >&2
+  exit 1
+fi
+
+# Verify SHA256 checksum
+BINARY_NAME="operator-sdk_${OS}_${ARCH}"
+CHECKSUM_URL="https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/checksums.txt"
+if ! download_and_verify_checksum /tmp/operator-sdk "$CHECKSUM_URL" "$BINARY_NAME"; then
+  echo "::error::operator-sdk binary checksum verification failed - the download may be corrupted or tampered with"
+  rm -f /tmp/operator-sdk
   exit 1
 fi
 

--- a/scripts/verify-checksum.sh
+++ b/scripts/verify-checksum.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Sourceable utility that provides SHA256 checksum verification for downloaded binaries.
+#
+# Usage:
+#   source "$(dirname "$0")/verify-checksum.sh"
+#   verify_checksum <file> <expected_sha256>
+#   download_and_verify_checksum <file> <checksum_url> [binary_name]
+
+# Verify a file's SHA256 checksum against an expected value.
+# Arguments:
+#   $1 - Path to the file to verify
+#   $2 - Expected SHA256 hash
+verify_checksum() {
+  local file="$1"
+  local expected="$2"
+  local actual
+
+  if [ ! -f "$file" ]; then
+    echo "::error::Checksum verification failed: file not found: $file"
+    return 1
+  fi
+
+  actual=$(sha256sum "$file" | awk '{print $1}')
+  if [ "$actual" != "$expected" ]; then
+    echo "::error::Checksum verification failed for $file"
+    echo "  Expected: $expected"
+    echo "  Actual:   $actual"
+    return 1
+  fi
+  echo "Checksum verified for $file"
+}
+
+# Download a checksum file and verify against a local file.
+# Supports multiple checksum file formats:
+#   - Hash only (e.g., Minikube: just the hash)
+#   - "hash  filename" (e.g., KinD, operator-sdk)
+#   - "hash filename" (e.g., Istio)
+# Arguments:
+#   $1 - Path to the file to verify
+#   $2 - URL to download the checksum from
+#   $3 - (Optional) Binary name to grep for in multi-entry checksum files
+download_and_verify_checksum() {
+  local file="$1"
+  local checksum_url="$2"
+  local binary_name="${3:-}"
+  local checksum_content
+  local expected
+
+  echo "Downloading checksum from: $checksum_url"
+  if ! checksum_content=$(curl -fsSL "$checksum_url" 2>/dev/null); then
+    echo "::warning::Could not download checksum file from $checksum_url - skipping verification"
+    return 0
+  fi
+
+  # If a binary name is given, extract the matching line from a multi-entry file
+  if [ -n "$binary_name" ]; then
+    local matching_line
+    matching_line=$(echo "$checksum_content" | grep -F "$binary_name" | head -1)
+    if [ -z "$matching_line" ]; then
+      echo "::warning::No checksum entry found for $binary_name - skipping verification"
+      return 0
+    fi
+    expected=$(echo "$matching_line" | awk '{print $1}')
+  else
+    # Single-entry file: extract just the hash (first field, or only content)
+    expected=$(echo "$checksum_content" | awk '{print $1}' | head -1)
+  fi
+
+  if [ -z "$expected" ]; then
+    echo "::warning::Could not parse checksum from downloaded file - skipping verification"
+    return 0
+  fi
+
+  verify_checksum "$file" "$expected"
+}


### PR DESCRIPTION
## Summary

- Adds SHA256 checksum verification after downloading KinD, Minikube, Istio, and operator-sdk binaries
- Creates a shared `scripts/verify-checksum.sh` helper with `verify_checksum` and `download_and_verify_checksum` functions to keep verification logic DRY
- Adds a `::warning::` annotation for OLM where no checksum file is published for the install script
- If verification fails, the corrupted download is removed and the action exits with `::error::`
- If the checksum file is unavailable (e.g., very old releases), a `::warning::` is emitted and installation proceeds gracefully

## Checksum sources

| Tool | Checksum URL pattern |
|------|---------------------|
| KinD | `kind-{os}-{arch}.sha256sum` from GitHub releases |
| Minikube | `minikube-{os}-{arch}.sha256` from GitHub releases |
| Istio | `istio-{version}-{os}-{arch}.tar.gz.sha256` from GitHub releases |
| operator-sdk | `checksums.txt` from GitHub releases (multi-entry, grep for binary name) |
| OLM | No checksum published for `install.sh` (warning emitted) |

## Test plan

- [ ] CI passes on all matrix combinations (KinD, Minikube across ubuntu-22.04/24.04 x86/arm)
- [ ] Istio test job passes with checksum verification
- [ ] operator-sdk installation succeeds with checksum verification
- [ ] OLM installation succeeds with warning annotation visible in logs

Closes #138