### PR TITLE
feat: Add persistent volume configuration options

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -184,6 +184,18 @@ inputs:
     description: 'Preview what the action would do without executing. Prints configuration summary and exits'
     required: false
     default: 'false'
+  createPersistentVolumes:
+    description: 'Create sample PersistentVolumes using hostPath for testing'
+    required: false
+    default: 'false'
+  persistentVolumeCount:
+    description: 'Number of PersistentVolumes to create'
+    required: false
+    default: '5'
+  persistentVolumeSize:
+    description: 'Size of each PersistentVolume (e.g., 10Gi, 1Gi, 500Mi)'
+    required: false
+    default: '10Gi'
 
 runs:
   using: 'composite'
@@ -535,6 +547,37 @@ runs:
         if [[ "$DRY_RUN" != "true" && "$DRY_RUN" != "false" ]]; then
           echo "Invalid dryRun value: $DRY_RUN"
           echo "Must be 'true' or 'false'"
+          exit 1
+        fi
+
+    - name: Validate createPersistentVolumes input
+      shell: bash
+      run: |
+        if [[ "${{ inputs.createPersistentVolumes }}" != "true" && "${{ inputs.createPersistentVolumes }}" != "false" ]]; then
+          echo "Invalid createPersistentVolumes value: ${{ inputs.createPersistentVolumes }}"
+          echo "Must be 'true' or 'false'"
+          exit 1
+        fi
+
+    - name: Validate persistentVolumeCount input
+      if: ${{ inputs.createPersistentVolumes == 'true' }}
+      shell: bash
+      run: |
+        COUNT="${{ inputs.persistentVolumeCount }}"
+        if ! [[ "$COUNT" =~ ^[0-9]+$ ]] || [ "$COUNT" -lt 1 ] || [ "$COUNT" -gt 100 ]; then
+          echo "Invalid persistentVolumeCount: $COUNT"
+          echo "Must be a number between 1 and 100"
+          exit 1
+        fi
+
+    - name: Validate persistentVolumeSize input
+      if: ${{ inputs.createPersistentVolumes == 'true' }}
+      shell: bash
+      run: |
+        SIZE="${{ inputs.persistentVolumeSize }}"
+        if ! [[ "$SIZE" =~ ^[0-9]+(Ki|Mi|Gi|Ti|Pi|Ei)?$ ]]; then
+          echo "Invalid persistentVolumeSize: $SIZE"
+          echo "Must be a valid Kubernetes quantity (e.g., 10Gi, 1Gi, 500Mi)"
           exit 1
         fi
 
@@ -1032,6 +1075,11 @@ runs:
       shell: bash
       run: |
         kubectl delete storageclass standard --ignore-not-found
+
+    - name: Create persistent volumes
+      if: ${{ inputs.createPersistentVolumes == 'true' && inputs.dryRun != 'true' }}
+      shell: bash
+      run: ${{ github.action_path }}/scripts/create-persistent-volumes.sh "${{ inputs.persistentVolumeCount }}" "${{ inputs.persistentVolumeSize }}"
 
     - name: Remove the control plane taint
       if: ${{ inputs.removeControlPlaneTaint == 'true' && inputs.dryRun != 'true' }}

--- a/scripts/create-persistent-volumes.sh
+++ b/scripts/create-persistent-volumes.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PV_COUNT="${1:-5}"
+PV_SIZE="${2:-10Gi}"
+
+echo "::group::Creating $PV_COUNT PersistentVolumes ($PV_SIZE each)"
+trap 'echo "::endgroup::"' EXIT
+
+# Verify kubectl is available
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo "Error: kubectl is not installed." >&2
+  exit 1
+fi
+
+# Create a StorageClass for the test PVs
+echo "Creating test-local StorageClass..."
+kubectl apply -f - <<EOF
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: test-local
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+EOF
+
+# Create PersistentVolumes
+for i in $(seq 1 "$PV_COUNT"); do
+  PV_NAME="test-pv-${i}"
+  HOST_PATH="/tmp/test-pvs/${PV_NAME}"
+
+  echo "Creating PersistentVolume: $PV_NAME ($PV_SIZE)"
+  kubectl apply -f - <<EOF
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: ${PV_NAME}
+  labels:
+    type: test-local
+spec:
+  capacity:
+    storage: ${PV_SIZE}
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Delete
+  storageClassName: test-local
+  hostPath:
+    path: ${HOST_PATH}
+    type: DirectoryOrCreate
+EOF
+done
+
+echo ""
+echo "Created $PV_COUNT PersistentVolumes:"
+kubectl get pv -l type=test-local
+echo ""
+echo "StorageClass:"
+kubectl get storageclass test-local
+echo ""
+echo "PersistentVolumes created successfully!"


### PR DESCRIPTION
## Summary

- Add `createPersistentVolumes` (boolean, default: `false`) input to create sample PersistentVolumes using hostPath
- Add `persistentVolumeCount` (number, default: `5`) input to control how many PVs to create
- Add `persistentVolumeSize` (string, default: `10Gi`) input to set the size of each PV
- Creates a `test-local` StorageClass with `WaitForFirstConsumer` binding mode
- PVs are named `test-pv-1`, `test-pv-2`, etc. and use hostPath for testing purposes
- Includes input validation (boolean, numeric range 1-100, Kubernetes quantity format)
- Integrated into dry-run summary and deployment summary output

## Test plan

- [ ] CI passes (lint + integration tests)
- [ ] Verify `createPersistentVolumes: true` creates the expected PVs and StorageClass
- [ ] Verify default behavior (false) does not create any PVs
- [ ] Verify input validation rejects invalid values (non-boolean, count < 1, bad size format)
- [ ] Verify dry-run mode shows PV configuration

Closes #244