### PR TITLE
Add progress indicators to wait-for-pods.sh

### DIFF
--- a/scripts/wait-for-pods.sh
+++ b/scripts/wait-for-pods.sh
@@ -13,6 +13,80 @@ timeout=1200  # 20 minutes in seconds
 elapsed=0
 interval=10
 
+# Format elapsed seconds as human-readable time (e.g., "2m 30s")
+format_time() {
+  local secs=$1
+  local mins=$((secs / 60))
+  local rem=$((secs % 60))
+  if [ "$mins" -gt 0 ]; then
+    echo "${mins}m ${rem}s"
+  else
+    echo "${rem}s"
+  fi
+}
+
+# Print a progress summary of pod states
+print_pod_progress() {
+  local pods=$1
+  local time_str=$2
+
+  local total=0
+  local ready=0
+  local pending=0
+  local initializing=0
+  local failed=0
+  local other=0
+
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    total=$((total + 1))
+    local status
+    status=$(echo "$line" | awk '{print $4}')
+    case "$status" in
+      Running|Completed|Succeeded)
+        ready=$((ready + 1))
+        ;;
+      Pending)
+        pending=$((pending + 1))
+        ;;
+      Init:*|PodInitializing)
+        initializing=$((initializing + 1))
+        ;;
+      Error|CrashLoopBackOff|ImagePullBackOff|ErrImagePull|CreateContainerError|InvalidImageName)
+        failed=$((failed + 1))
+        ;;
+      *)
+        other=$((other + 1))
+        ;;
+    esac
+  done <<< "$pods"
+
+  # Build detail string
+  local details=""
+  if [ "$pending" -gt 0 ]; then
+    details="${pending} pending"
+  fi
+  if [ "$initializing" -gt 0 ]; then
+    [ -n "$details" ] && details="${details}, "
+    details="${details}${initializing} initializing"
+  fi
+  if [ "$failed" -gt 0 ]; then
+    [ -n "$details" ] && details="${details}, "
+    details="${details}${failed} failed"
+  fi
+  if [ "$other" -gt 0 ]; then
+    [ -n "$details" ] && details="${details}, "
+    details="${details}${other} other"
+  fi
+
+  echo "[${time_str}] Pods: ${ready}/${total} ready (${details})"
+
+  # List pods that are not ready
+  echo "$pods" | awk '$4 != "Running" && $4 != "Completed" && $4 != "Succeeded" {
+    printf "  Not ready: %-50s %-20s %s\n", $2, $4, "(ns: " $1 ")"
+  }'
+}
+
 # Build the list of namespaces to monitor
 get_namespaces() {
   if [ -n "${WAIT_NAMESPACES:-}" ]; then
@@ -60,11 +134,12 @@ fi
 while true; do
   pod_output=$(get_pods)
   if [ -z "$pod_output" ] || echo "$pod_output" | awk '{if ($4 != "Running" && $4 != "Completed") exit 1}'; then
-    echo "All pods are running or completed"
+    time_str=$(format_time "$elapsed")
+    echo "[${time_str}] All pods are running or completed"
     break
   else
-    echo "Waiting for all pods to be running or completed..."
-    echo "$pod_output" | awk '{if ($4 != "Running" && $4 != "Completed") print "Pending pod: " $2 " in namespace: " $1}'
+    time_str=$(format_time "$elapsed")
+    print_pod_progress "$pod_output" "$time_str"
     sleep $interval
     elapsed=$((elapsed + interval))
     if [ $elapsed -ge $timeout ]; then


### PR DESCRIPTION
## Summary

- Replace generic "Waiting for all pods..." message with detailed progress output on every iteration (every 10s)
- Show elapsed time, pod readiness ratio, and state breakdown (pending, initializing, failed)
- List specific pods that are not yet ready with their current status and namespace

Example output:
```
[2m 30s] Pods: 12/15 ready (2 pending, 1 initializing)
  Not ready: coredns-5d78c9869d-abc12                        Pending              (ns: kube-system)
  Not ready: calico-node-xyz99                                Init:0/3             (ns: calico-system)
  Not ready: metrics-server-6d94bc8694-def34                  PodInitializing      (ns: kube-system)
```

Closes #211

## Test plan

- [ ] Verify lint passes (shellcheck)
- [ ] Deploy a KinD cluster with `waitForPodsReady: true` and confirm progress output appears in logs
- [ ] Deploy with Calico/Istio/OLM to test with pods in various init states
- [ ] Verify timeout behavior is unchanged