### PR TITLE
Add resource limit configuration inputs (CPU/memory)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -180,6 +180,14 @@ inputs:
     description: 'Timeout in seconds for component installation (kubectl wait commands)'
     required: false
     default: '300'
+  clusterCPUs:
+    description: 'Number of CPUs to allocate to the cluster (e.g., 2). Only applies to Minikube provider'
+    required: false
+    default: '2'
+  clusterMemory:
+    description: 'Memory in MB to allocate to the cluster (e.g., 4096). Empty means use provider default. Only applies to Minikube provider'
+    required: false
+    default: ''
   dryRun:
     description: 'Preview what the action would do without executing. Prints configuration summary and exits'
     required: false
@@ -562,6 +570,39 @@ runs:
           echo "Must be a positive integer (seconds)"
           exit 1
         fi
+
+    - name: Validate clusterCPUs input
+      shell: bash
+      run: |
+        CPUS="${{ inputs.clusterCPUs }}"
+        if ! [[ "$CPUS" =~ ^[0-9]+$ ]] || [ "$CPUS" -lt 1 ]; then
+          echo "Invalid clusterCPUs: $CPUS"
+          echo "Must be a positive integer"
+          exit 1
+        fi
+
+    - name: Validate clusterMemory input
+      if: ${{ inputs.clusterMemory != '' }}
+      shell: bash
+      run: |
+        MEMORY="${{ inputs.clusterMemory }}"
+        if ! [[ "$MEMORY" =~ ^[0-9]+$ ]] || [ "$MEMORY" -lt 1 ]; then
+          echo "Invalid clusterMemory: $MEMORY"
+          echo "Must be a positive integer (MB)"
+          exit 1
+        fi
+
+    - name: Notice about resource limits for KinD provider
+      if: ${{ inputs.clusterProvider == 'kind' && (inputs.clusterCPUs != '2' || inputs.clusterMemory != '') }}
+      shell: bash
+      run: |
+        echo "::notice::KinD runs as Docker containers. CPU and memory limits are controlled by the Docker daemon configuration, not by clusterCPUs/clusterMemory inputs."
+
+    - name: Notice about resource limits for k3s provider
+      if: ${{ inputs.clusterProvider == 'k3s' && (inputs.clusterCPUs != '2' || inputs.clusterMemory != '') }}
+      shell: bash
+      run: |
+        echo "::notice::k3s runs as native processes on the host. CPU and memory limits are controlled at the OS level, not by clusterCPUs/clusterMemory inputs."
 
     - name: Validate kindConfigPath input
       if: ${{ inputs.kindConfigPath != '' && inputs.clusterProvider == 'kind' }}

--- a/scripts/start-minikube.sh
+++ b/scripts/start-minikube.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 # Script to start Minikube cluster with configuration
-# Usage: start-minikube.sh <node_image> <disable_cni> <driver> <api_port> <num_control_plane> <num_workers> [api_server_address] [cluster_name]
-# Example: start-minikube.sh "kindest/node:v1.34.0@sha256:..." true docker 6443 1 1 0.0.0.0 minikube
+# Usage: start-minikube.sh <node_image> <disable_cni> <driver> <api_port> <num_control_plane> <num_workers> [api_server_address] [cluster_name] [cpus] [memory]
+# Example: start-minikube.sh "kindest/node:v1.34.0@sha256:..." true docker 6443 1 1 0.0.0.0 minikube 2 4096
 
 NODE_IMAGE="${1:-}"
 DISABLE_CNI="${2:-false}"
@@ -13,6 +13,8 @@ NUM_CONTROL_PLANE="${5:-1}"
 NUM_WORKERS="${6:-0}"
 API_SERVER_ADDRESS="${7:-0.0.0.0}"
 CLUSTER_NAME="${8:-minikube}"
+CLUSTER_CPUS="${9:-2}"
+CLUSTER_MEMORY="${10:-}"
 
 if [ -z "$NODE_IMAGE" ]; then
   echo "Usage: $0 <node_image> [disable_cni] [driver] [api_port] [num_control_plane] [num_workers]"


### PR DESCRIPTION
## Summary

- Adds `clusterCPUs` input (string, default `'2'`) to configure the number of CPUs allocated to the cluster
- Adds `clusterMemory` input (string, default `''`) to configure memory in MB (empty = provider default)
- For Minikube: passes `--cpus` and `--memory` flags to `minikube start`
- For KinD: prints a `::notice::` that CPU/memory are controlled by Docker daemon config
- For k3s: prints a `::notice::` that resource limits apply at OS level
- Input validation ensures both values are positive integers when set

## Test plan

- [ ] Verify existing CI tests pass (no behavioral change with defaults)
- [ ] Verify dry-run summary includes new CPU/memory fields
- [ ] Test Minikube with custom `clusterCPUs: '4'` and `clusterMemory: '8192'`
- [ ] Verify KinD notice appears when non-default resource values are set with KinD provider

Closes #229