### PR TITLE
Add skipDiskCleanup input for self-hosted runners

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -798,7 +798,7 @@ runs:
       run: ${{ github.action_path }}/scripts/pre-flight-check.sh
 
     - name: Optimize disk space and relocate Docker storage
-      if: ${{ inputs.dryRun != 'true' }}
+      if: ${{ inputs.dryRun != 'true' && inputs.skipDiskCleanup != 'true' }}
       uses: palmsoftware/quick-cleanup@v0
       with:
         cleanup-mode: auto
@@ -896,7 +896,7 @@ runs:
       run: ${{ github.action_path }}/scripts/bootstrap-docker.sh
 
     - name: Final pre-cluster disk optimization
-      if: ${{ inputs.dryRun != 'true' }}
+      if: ${{ inputs.dryRun != 'true' && inputs.skipDiskCleanup != 'true' }}
       shell: bash
       run: ${{ github.action_path }}/scripts/pre-cluster-optimization.sh
 


### PR DESCRIPTION
## Summary

- Adds a new `skipDiskCleanup` boolean input (default: `false`) that allows users to skip aggressive disk cleanup steps
- When set to `true`, skips both the `palmsoftware/quick-cleanup` action and the `pre-cluster-optimization.sh` step
- Self-hosted runners typically have ample disk space and don't need the cleanup designed for free-tier GitHub-hosted runners
- Includes input validation and dry-run summary support

## Test plan

- [ ] CI passes with default `skipDiskCleanup: false` (existing behavior unchanged)
- [ ] Verify the dry-run summary shows the new `Skip Disk Cleanup` option
- [ ] Validate that invalid values for `skipDiskCleanup` are rejected

Closes #180