### PR TITLE
feat: Make wait-for-pods timeout configurable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -84,6 +84,10 @@ inputs:
     description: 'Comma-separated list of namespaces to exclude from pod readiness monitoring'
     required: false
     default: ''
+  waitForPodsTimeout:
+    description: 'Timeout in seconds for waiting for pods to be ready (default: 1200 = 20 minutes)'
+    required: false
+    default: '1200'
   installIstio:
     description: 'Install Istio service mesh'
     required: false
@@ -390,6 +394,16 @@ runs:
         if [[ "$WAIT_FOR_PODS_READY" != "true" && "$WAIT_FOR_PODS_READY" != "false" ]]; then
           echo "Invalid waitForPodsReady value: $WAIT_FOR_PODS_READY"
           echo "Must be 'true' or 'false'"
+          exit 1
+        fi
+
+    - name: Validate waitForPodsTimeout input
+      shell: bash
+      run: |
+        TIMEOUT="${{ inputs.waitForPodsTimeout }}"
+        if ! [[ "$TIMEOUT" =~ ^[0-9]+$ ]] || [ "$TIMEOUT" -lt 60 ] || [ "$TIMEOUT" -gt 7200 ]; then
+          echo "Invalid waitForPodsTimeout: $TIMEOUT"
+          echo "Must be a number between 60 and 7200 (1 minute to 2 hours)"
           exit 1
         fi
 
@@ -1045,6 +1059,7 @@ runs:
       env:
         WAIT_NAMESPACES: ${{ inputs.waitForPodsNamespaces }}
         EXCLUDE_NAMESPACES: ${{ inputs.waitForPodsExcludeNamespaces }}
+        WAIT_TIMEOUT: ${{ inputs.waitForPodsTimeout }}
       run: ${{ github.action_path }}/scripts/wait-for-pods.sh
 
     - name: Clean up package manager cache

--- a/scripts/wait-for-pods.sh
+++ b/scripts/wait-for-pods.sh
@@ -9,7 +9,7 @@ if ! command -v kubectl >/dev/null 2>&1; then
   exit 1
 fi
 
-timeout=1200  # 20 minutes in seconds
+timeout="${WAIT_TIMEOUT:-1200}"  # Default: 20 minutes in seconds
 elapsed=0
 interval=10
 
@@ -142,7 +142,7 @@ while true; do
     print_pod_progress "$pod_output" "$time_str"
     sleep $interval
     elapsed=$((elapsed + interval))
-    if [ $elapsed -ge $timeout ]; then
+    if [ $elapsed -ge "$timeout" ]; then
       echo "Timeout reached: Not all pods are running or completed"
       echo ""
       echo "=== Pod State Dump (all namespaces) ==="


### PR DESCRIPTION
## Summary

- Adds a new `waitForPodsTimeout` input (string, default `'1200'`) to configure the timeout for waiting for pods to be ready
- Replaces the hardcoded 20-minute timeout in `scripts/wait-for-pods.sh` with the configurable value
- Validates the input is a number between 60 and 7200 (1 minute to 2 hours)

## Changes

**action.yml**:
- New `waitForPodsTimeout` input with description and default
- Validation step ensuring numeric value in range 60-7200
- Passes value to `wait-for-pods.sh` via `WAIT_TIMEOUT` env var

**scripts/wait-for-pods.sh**:
- Uses `WAIT_TIMEOUT` env var with fallback to 1200s default
- Logs the configured timeout for visibility
- Quotes `$timeout` in comparison to satisfy shellcheck

## Usage

```yaml
- uses: palmsoftware/quick-k8s@v0
  with:
    waitForPodsReady: true
    waitForPodsTimeout: '600'  # 10 minutes
```

## Test plan

- [ ] CI passes (lint + integration tests)
- [ ] Default behavior unchanged (1200s timeout when input omitted)
- [ ] Validation rejects non-numeric, <60, or >7200 values

Closes #147