### PR TITLE
feat: Add MetalLB installation for LoadBalancer service support

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -495,3 +495,60 @@ jobs:
         run: |
           kubectl get pods -n monitoring -o wide
           kubectl get svc -n monitoring
+
+  # Test MetalLB installation
+  test-metallb:
+    needs: lint
+    if: ${{ needs.lint.result == 'success' }}
+    runs-on: ubuntu-24.04
+    env:
+      SHELL: /bin/bash
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v7
+
+      - name: Run the action with MetalLB
+        uses: ./
+        with:
+          clusterProvider: kind
+          installMetalLB: true
+          waitForPodsReady: true
+          installOLM: false
+          installIstio: false
+
+      - name: Verify MetalLB is running
+        run: |
+          echo "Checking metallb-system namespace..."
+          kubectl get namespace metallb-system
+          echo "Checking MetalLB pods..."
+          kubectl get pods -n metallb-system
+          echo "Verifying controller is ready..."
+          kubectl wait --namespace metallb-system --for=condition=ready pod --selector=app=metallb,component=controller --timeout=60s
+          echo "Verifying speaker pods are ready..."
+          kubectl wait --namespace metallb-system --for=condition=ready pod --selector=app=metallb,component=speaker --timeout=60s
+          echo "Checking IPAddressPool..."
+          kubectl get ipaddresspool -n metallb-system
+          echo "Checking L2Advertisement..."
+          kubectl get l2advertisement -n metallb-system
+          echo "MetalLB installation verified!"
+
+      - name: Test LoadBalancer service gets external IP
+        run: |
+          echo "Creating a test LoadBalancer service..."
+          kubectl create deployment nginx-test --image=nginx:latest
+          kubectl expose deployment nginx-test --port=80 --type=LoadBalancer
+          echo "Waiting for external IP assignment..."
+          for i in $(seq 1 30); do
+            EXTERNAL_IP=$(kubectl get svc nginx-test -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null)
+            if [ -n "$EXTERNAL_IP" ]; then
+              echo "LoadBalancer service assigned external IP: $EXTERNAL_IP"
+              kubectl get svc nginx-test
+              echo "MetalLB LoadBalancer test passed!"
+              exit 0
+            fi
+            echo "Attempt $i/30: Waiting for external IP..."
+            sleep 5
+          done
+          echo "FAIL: LoadBalancer service did not receive an external IP"
+          kubectl get svc nginx-test -o yaml
+          exit 1

--- a/action.yml
+++ b/action.yml
@@ -120,6 +120,14 @@ inputs:
     description: 'The version of metrics-server to install'
     required: false
     default: 'v0.9.0'
+  installMetalLB:
+    description: 'Install MetalLB for LoadBalancer service support on local clusters'
+    required: false
+    default: 'false'
+  metalLBVersion:
+    description: 'The version of MetalLB to install'
+    required: false
+    default: 'v0.16.0'
   workerNodeLabels:
     description: 'Comma-separated list of key=value labels to apply to worker nodes (e.g., "node-role.kubernetes.io/worker=worker,env=test")'
     required: false
@@ -449,6 +457,22 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
         METRICS_SERVER_VERSION: ${{ inputs.metricsServerVersion }}
       run: ${{ github.action_path }}/scripts/validate-github-version.sh "metrics-server" "kubernetes-sigs/metrics-server" "$METRICS_SERVER_VERSION"
+
+    - name: Validate installMetalLB input
+      shell: bash
+      run: |
+        if [[ "${{ inputs.installMetalLB }}" != "true" && "${{ inputs.installMetalLB }}" != "false" ]]; then
+          echo "Invalid installMetalLB value: ${{ inputs.installMetalLB }}"
+          echo "Must be 'true' or 'false'"
+          exit 1
+        fi
+
+    - name: Validate MetalLB version input
+      if: ${{ inputs.installMetalLB == 'true' }}
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: ${{ github.action_path }}/scripts/validate-github-version.sh "MetalLB" "metallb/metallb" "${{ inputs.metalLBVersion }}"
 
     - name: Validate installOperatorSdk input
       shell: bash
@@ -995,6 +1019,13 @@ runs:
         COMPONENT_TIMEOUT: ${{ inputs.componentTimeout }}
         METRICS_SERVER_VERSION: ${{ inputs.metricsServerVersion }}
       run: ${{ github.action_path }}/scripts/install-metrics-server.sh "$METRICS_SERVER_VERSION"
+
+    - name: Install MetalLB
+      if: ${{ inputs.installMetalLB == 'true' && inputs.dryRun != 'true' }}
+      shell: bash
+      env:
+        COMPONENT_TIMEOUT: ${{ inputs.componentTimeout }}
+      run: ${{ github.action_path }}/scripts/install-metallb.sh ${{ inputs.metalLBVersion }} ${{ inputs.clusterProvider }}
 
     - name: Install operator-sdk
       if: ${{ inputs.installOperatorSdk == 'true' && inputs.dryRun != 'true' }}

--- a/scripts/install-metallb.sh
+++ b/scripts/install-metallb.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+METALLB_VERSION="${1:-v0.16.0}"
+CLUSTER_PROVIDER="${2:-kind}"
+TIMEOUT="${COMPONENT_TIMEOUT:-300}"
+
+# shellcheck source=diagnose-failure.sh
+source "$(dirname "$0")/diagnose-failure.sh"
+
+echo "::group::Installing MetalLB $METALLB_VERSION"
+trap 'echo "::endgroup::"' EXIT
+
+echo "Installing MetalLB version $METALLB_VERSION"
+
+# Verify required tools are available
+for cmd in kubectl docker; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: $cmd is not installed." >&2
+    exit 1
+  fi
+done
+
+MANIFEST_URL="https://raw.githubusercontent.com/metallb/metallb/${METALLB_VERSION}/config/manifests/metallb-native.yaml"
+echo "Downloading MetalLB manifest from: $MANIFEST_URL"
+
+apply_output=$(kubectl apply --timeout=5m -f "$MANIFEST_URL" 2>&1) || {
+  echo "$apply_output"
+  diagnose_failure "MetalLB" "$apply_output"
+  exit 1
+}
+echo "$apply_output"
+
+echo "Waiting for MetalLB controller to be ready..."
+wait_output=$(kubectl wait --namespace metallb-system \
+  --for=condition=ready pod \
+  --selector=app=metallb,component=controller \
+  --timeout="${TIMEOUT}s" 2>&1) || {
+  echo "$wait_output"
+  dump_pod_status "metallb-system" "MetalLB"
+  diagnose_failure "MetalLB" "$wait_output"
+  exit 1
+}
+echo "$wait_output"
+
+echo "Waiting for MetalLB speaker pods to be ready..."
+wait_output=$(kubectl wait --namespace metallb-system \
+  --for=condition=ready pod \
+  --selector=app=metallb,component=speaker \
+  --timeout="${TIMEOUT}s" 2>&1) || {
+  echo "$wait_output"
+  dump_pod_status "metallb-system" "MetalLB"
+  diagnose_failure "MetalLB" "$wait_output"
+  exit 1
+}
+echo "$wait_output"
+
+kubectl get pods -n metallb-system
+
+# Auto-detect the IP range from the Docker bridge network used by the cluster
+echo "Detecting Docker network subnet for address pool configuration..."
+
+if [ "$CLUSTER_PROVIDER" = "kind" ]; then
+  NETWORK_NAME="kind"
+else
+  NETWORK_NAME="bridge"
+fi
+
+SUBNET=$(docker network inspect "$NETWORK_NAME" -f '{{(index .IPAM.Config 0).Subnet}}' 2>/dev/null) || {
+  echo "Warning: Could not detect Docker network subnet, using default 172.18.255.200-172.18.255.250"
+  SUBNET=""
+}
+
+if [ -n "$SUBNET" ]; then
+  # Extract base network and construct a range in the .255.200-.255.250 space
+  # For example, 172.18.0.0/16 -> 172.18.255.200-172.18.255.250
+  #              192.168.49.0/24 -> 192.168.49.200-192.168.49.250
+  IFS='/' read -r NETWORK_ADDR PREFIX_LEN <<< "$SUBNET"
+  IFS='.' read -r O1 O2 O3 _O4 <<< "$NETWORK_ADDR"
+
+  if [ "$PREFIX_LEN" -le 16 ]; then
+    POOL_START="${O1}.${O2}.255.200"
+    POOL_END="${O1}.${O2}.255.250"
+  else
+    POOL_START="${O1}.${O2}.${O3}.200"
+    POOL_END="${O1}.${O2}.${O3}.250"
+  fi
+else
+  POOL_START="172.18.255.200"
+  POOL_END="172.18.255.250"
+fi
+
+echo "Configuring MetalLB address pool: ${POOL_START}-${POOL_END}"
+
+kubectl apply -f - <<EOF
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: quick-k8s-pool
+  namespace: metallb-system
+spec:
+  addresses:
+    - ${POOL_START}-${POOL_END}
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: quick-k8s-l2
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+    - quick-k8s-pool
+EOF
+
+echo "MetalLB $METALLB_VERSION installed successfully!"
+echo "LoadBalancer IP range: ${POOL_START}-${POOL_END}"


### PR DESCRIPTION
## Summary

- Adds `installMetalLB` (boolean) and `metalLBVersion` (string, default `v0.16.0`) inputs to enable MetalLB load balancer on local clusters
- Creates `scripts/install-metallb.sh` that applies the official MetalLB native manifest, waits for controller and speaker pods to be ready, then auto-detects the Docker network subnet to configure an IPAddressPool and L2Advertisement
- Adds input validation (boolean + GitHub release version check), dry-run summary entry, deployment summary output, and a CI test job that verifies a LoadBalancer service receives an external IP

Closes #235

## Test plan

- [ ] Lint job passes (shellcheck)
- [ ] `test-metallb` CI job verifies MetalLB pods are running, IPAddressPool and L2Advertisement are created, and a LoadBalancer service gets an external IP
- [ ] Existing CI jobs unaffected (MetalLB is opt-in, default false)