### PR TITLE
Expose OLM version as action input

### DIFF
--- a/.github/workflows/olm-update.yml
+++ b/.github/workflows/olm-update.yml
@@ -63,31 +63,31 @@ jobs:
           
           get_olm_version
 
-      - name: Update OLM version in install-olm.sh
+      - name: Update OLM version in action.yml
         id: update_version
         run: |
           version=${{ steps.get_olm_version.outputs.olm_version }}
-          
+
           # Double-check the version is valid before updating
           if [ -z "$version" ] || [ "$version" = "null" ] || ! [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Error: Invalid OLM version '$version' - aborting update"
             exit 1
           fi
-          
+
           echo "Updating OLM version to: $version"
-          
+
           # Check if the version is already current
-          current_version=$(grep -o 'OLM_VERSION="v[0-9]\+\.[0-9]\+\.[0-9]\+"' scripts/install-olm.sh | sed 's/OLM_VERSION="\(.*\)"/\1/')
+          current_version=$(grep -A2 "olmVersion:" action.yml | grep "default:" | sed "s/.*default: *'\(.*\)'/\1/")
           if [ "$current_version" = "$version" ]; then
             echo "OLM version is already up to date ($version)"
             echo "updated=false" >> $GITHUB_OUTPUT
             exit 0
           fi
-          
-          # Update the version
-          sed -i.bak -E "s/OLM_VERSION=\"v[0-9]+\.[0-9]+\.[0-9]+\"/OLM_VERSION=\"$version\"/" scripts/install-olm.sh
-          rm scripts/install-olm.sh.bak
-          
+
+          # Update the default version in action.yml olmVersion input
+          sed -i.bak -E "/^  olmVersion:/,/^  [a-zA-Z]/ s/(default: ').*(')$/\1$version\2/" action.yml
+          rm action.yml.bak
+
           echo "Successfully updated OLM version from $current_version to $version"
           echo "updated=true" >> $GITHUB_OUTPUT
 
@@ -98,6 +98,6 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
           commit-message: "Update OLM version to ${{ steps.get_olm_version.outputs.olm_version }}"
           title: "Update OLM version to ${{ steps.get_olm_version.outputs.olm_version }}"
-          body: "Automated PR to update OLM version in install-olm.sh to the latest release."
+          body: "Automated PR to update OLM version in action.yml to the latest release."
           branch: "update-olm-version-${{ steps.get_olm_version.outputs.olm_version }}"
           delete-branch: true

--- a/action.yml
+++ b/action.yml
@@ -64,6 +64,10 @@ inputs:
     description: 'Install the Operator Lifecycle Manager'
     required: false
     default: 'false'
+  olmVersion:
+    description: 'The version of OLM to install'
+    required: false
+    default: 'v0.45.0'
   removeDefaultStorageClass:
     description: 'Remove the default storage class'
     required: false
@@ -348,6 +352,13 @@ runs:
           echo "Must be 'true' or 'false'"
           exit 1
         fi
+
+    - name: Validate OLM version input
+      if: ${{ inputs.installOLM == 'true' }}
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: ${{ github.action_path }}/scripts/validate-github-version.sh "OLM" "operator-framework/operator-lifecycle-manager" "${{ inputs.olmVersion }}"
 
     - name: Validate installIstio input
       shell: bash
@@ -960,7 +971,7 @@ runs:
       shell: bash
       env:
         COMPONENT_TIMEOUT: ${{ inputs.componentTimeout }}
-      run: ${{ github.action_path }}/scripts/install-olm.sh
+      run: ${{ github.action_path }}/scripts/install-olm.sh ${{ inputs.olmVersion }}
 
     - name: Install Istio
       if: ${{ inputs.installIstio == 'true' && inputs.dryRun != 'true' }}

--- a/scripts/install-olm.sh
+++ b/scripts/install-olm.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-OLM_VERSION="v0.45.0"
+OLM_VERSION="${1:-v0.45.0}"
 TIMEOUT="${COMPONENT_TIMEOUT:-300}"
 
 # shellcheck source=diagnose-failure.sh


### PR DESCRIPTION
## Summary

- Adds `olmVersion` input to `action.yml` (default: `v0.45.0`) so users can specify which OLM version to install
- Updates `install-olm.sh` to accept the version as an argument instead of hardcoding it
- Adds version validation using `validate-github-version.sh`, matching the pattern used by all other versioned components
- Shows the OLM version in both the terminal deployment summary and GitHub Step Summary
- Updates the nightly `olm-update.yml` workflow to modify `action.yml` instead of the install script

## Usage

```yaml
- uses: palmsoftware/quick-k8s@v0
  with:
    installOLM: true
    olmVersion: 'v0.45.0'  # optional, defaults to v0.45.0
```

## Test plan

- [ ] CI lint job passes (shellcheck)
- [ ] CI OLM integration tests pass with default version
- [ ] Verify version validation rejects invalid versions (handled by existing validate-github-version.sh tests)

Closes #172