### PR TITLE
Add CNI plugin choice beyond Calico (Cilium, Flannel)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -152,8 +152,12 @@ inputs:
     description: 'The version of Thanos to install'
     required: false
     default: 'v0.42.0'
+  cniPlugin:
+    description: 'CNI plugin to install when default CNI is disabled (calico, cilium, flannel, none). Use none to bring your own CNI'
+    required: false
+    default: 'calico'
   installCalico:
-    description: 'Install Calico CNI when default CNI is disabled. Set to false to bring your own CNI (e.g., Multus, OVN)'
+    description: 'Deprecated: use cniPlugin instead. Install Calico CNI when default CNI is disabled'
     required: false
     default: 'true'
   installSampleNetworkPolicies:
@@ -288,7 +292,7 @@ runs:
         fi
 
     - name: Validate Calico version input
-      if: ${{ inputs.disableDefaultCni == 'true' && inputs.installCalico != 'false' }}
+      if: ${{ inputs.disableDefaultCni == 'true' && inputs.cniPlugin == 'calico' }}
       shell: bash
       env:
         GITHUB_TOKEN: ${{ github.token }}
@@ -515,6 +519,23 @@ runs:
           echo "Must be 'true' or 'false'"
           exit 1
         fi
+
+    - name: Validate cniPlugin input
+      shell: bash
+      run: |
+        CNI="${{ inputs.cniPlugin }}"
+        if [[ "$CNI" != "calico" && "$CNI" != "cilium" && "$CNI" != "flannel" && "$CNI" != "none" ]]; then
+          echo "Invalid cniPlugin value: $CNI"
+          echo "Must be 'calico', 'cilium', 'flannel', or 'none'"
+          exit 1
+        fi
+
+    - name: Validate Flannel version input
+      if: ${{ inputs.disableDefaultCni == 'true' && inputs.cniPlugin == 'flannel' }}
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: ${{ github.action_path }}/scripts/validate-github-version.sh "Flannel" "flannel-io/flannel" "${{ inputs.flannelVersion }}"
 
     - name: Validate installLocalRegistry input
       shell: bash
@@ -934,8 +955,22 @@ runs:
         CALICO_VERSION: ${{ inputs.calicoVersion }}
       run: ${{ github.action_path }}/scripts/install-calico.sh "$CALICO_VERSION"
 
+    - name: Install Cilium CNI
+      if: ${{ inputs.disableDefaultCni == 'true' && inputs.cniPlugin == 'cilium' && inputs.dryRun != 'true' }}
+      shell: bash
+      env:
+        COMPONENT_TIMEOUT: ${{ inputs.componentTimeout }}
+      run: ${{ github.action_path }}/scripts/install-cilium.sh
+
+    - name: Install Flannel CNI
+      if: ${{ inputs.disableDefaultCni == 'true' && inputs.cniPlugin == 'flannel' && inputs.dryRun != 'true' }}
+      shell: bash
+      env:
+        COMPONENT_TIMEOUT: ${{ inputs.componentTimeout }}
+      run: ${{ github.action_path }}/scripts/install-flannel.sh "${{ inputs.flannelVersion }}"
+
     - name: Skip CNI installation (bring your own CNI)
-      if: ${{ inputs.disableDefaultCni == 'true' && inputs.installCalico == 'false' && inputs.dryRun != 'true' }}
+      if: ${{ inputs.disableDefaultCni == 'true' && inputs.cniPlugin == 'none' && inputs.dryRun != 'true' }}
       shell: bash
       run: |
         echo "Skipping Calico CNI installation - installCalico is set to false"

--- a/scripts/install-cilium.sh
+++ b/scripts/install-cilium.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CILIUM_VERSION="${1:-}"
+TIMEOUT="${COMPONENT_TIMEOUT:-300}"
+
+# shellcheck source=diagnose-failure.sh
+source "$(dirname "$0")/diagnose-failure.sh"
+
+echo "::group::Installing Cilium CNI"
+trap 'echo "::endgroup::"' EXIT
+
+# Verify required tools are available
+for cmd in curl kubectl; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: $cmd is not installed." >&2
+    exit 1
+  fi
+done
+
+# Determine architecture
+CLI_ARCH="amd64"
+if [ "$(uname -m)" = "aarch64" ]; then
+  CLI_ARCH="arm64"
+fi
+
+# Determine Cilium CLI version
+if [ -n "$CILIUM_VERSION" ]; then
+  CILIUM_CLI_VERSION="$CILIUM_VERSION"
+  echo "Installing Cilium CLI version $CILIUM_CLI_VERSION..."
+else
+  echo "Fetching latest stable Cilium CLI version..."
+  CILIUM_CLI_VERSION=$(curl -sS --retry 3 --retry-delay 5 https://raw.githubusercontent.com/cilium/cilium-cli/main/stable.txt)
+  echo "Latest Cilium CLI version: $CILIUM_CLI_VERSION"
+fi
+
+# Download Cilium CLI with retry
+max_attempts=3
+attempt=1
+delay=5
+
+while [ $attempt -le $max_attempts ]; do
+  echo "Attempt $attempt/$max_attempts: Downloading Cilium CLI..."
+  DOWNLOAD_URL="https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-linux-${CLI_ARCH}.tar.gz"
+  CHECKSUM_URL="${DOWNLOAD_URL}.sha256sum"
+
+  if curl -L --fail --retry 3 -o "/tmp/cilium-linux-${CLI_ARCH}.tar.gz" "$DOWNLOAD_URL" && \
+     curl -L --fail --retry 3 -o "/tmp/cilium-linux-${CLI_ARCH}.tar.gz.sha256sum" "$CHECKSUM_URL"; then
+
+    # Verify checksum
+    if (cd /tmp && sha256sum --check "cilium-linux-${CLI_ARCH}.tar.gz.sha256sum"); then
+      echo "Checksum verified successfully"
+      sudo tar xzf "/tmp/cilium-linux-${CLI_ARCH}.tar.gz" -C /usr/local/bin
+      rm -f "/tmp/cilium-linux-${CLI_ARCH}.tar.gz" "/tmp/cilium-linux-${CLI_ARCH}.tar.gz.sha256sum"
+      break
+    else
+      echo "Checksum verification failed"
+      rm -f "/tmp/cilium-linux-${CLI_ARCH}.tar.gz" "/tmp/cilium-linux-${CLI_ARCH}.tar.gz.sha256sum"
+    fi
+  fi
+
+  if [ $attempt -eq $max_attempts ]; then
+    echo "::error::Failed to download Cilium CLI after $max_attempts attempts"
+    exit 1
+  fi
+
+  echo "Retrying in $delay seconds..."
+  sleep $delay
+  delay=$((delay * 2))
+  attempt=$((attempt + 1))
+done
+
+# Verify Cilium CLI installation
+if ! command -v cilium >/dev/null 2>&1; then
+  echo "::error::Cilium CLI installation failed - binary not found"
+  exit 1
+fi
+echo "Cilium CLI installed: $(cilium version --client 2>/dev/null || cilium version 2>&1 | head -1)"
+
+# Install Cilium into the cluster
+echo "Installing Cilium into the cluster..."
+install_output=$(cilium install --wait=false 2>&1) || {
+  echo "$install_output"
+  diagnose_failure "Cilium" "$install_output"
+  exit 1
+}
+echo "$install_output"
+
+# Wait for Cilium to be ready
+echo "Waiting for Cilium to be ready (timeout: ${TIMEOUT}s)..."
+wait_output=$(cilium status --wait --wait-duration "${TIMEOUT}s" 2>&1) || {
+  echo "$wait_output"
+  dump_pod_status "kube-system" "Cilium"
+  diagnose_failure "Cilium" "$wait_output"
+  exit 1
+}
+echo "$wait_output"
+
+kubectl get pods -n kube-system -l k8s-app=cilium
+echo "Cilium CNI installed successfully!"

--- a/scripts/install-flannel.sh
+++ b/scripts/install-flannel.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FLANNEL_VERSION="${1:-v0.26.7}"
+TIMEOUT="${COMPONENT_TIMEOUT:-300}"
+
+# shellcheck source=diagnose-failure.sh
+source "$(dirname "$0")/diagnose-failure.sh"
+
+echo "::group::Installing Flannel CNI $FLANNEL_VERSION"
+trap 'echo "::endgroup::"' EXIT
+
+echo "Installing Flannel CNI version $FLANNEL_VERSION..."
+
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo "Error: kubectl is not installed." >&2
+  exit 1
+fi
+
+FLANNEL_URL="https://github.com/flannel-io/flannel/releases/download/${FLANNEL_VERSION}/kube-flannel.yml"
+
+max_attempts=3
+attempt=1
+delay=5
+
+while [ $attempt -le $max_attempts ]; do
+  echo "Attempt $attempt/$max_attempts: Applying Flannel manifest..."
+  apply_output=$(kubectl apply --timeout=5m -f "$FLANNEL_URL" 2>&1) && {
+    echo "$apply_output"
+    echo "Flannel manifest applied successfully"
+    break
+  }
+  exit_code=$?
+  echo "$apply_output"
+
+  if [ $attempt -eq $max_attempts ]; then
+    diagnose_failure "Flannel" "$apply_output"
+    exit $exit_code
+  fi
+
+  echo "Retrying in $delay seconds..."
+  sleep $delay
+  delay=$((delay * 2))
+  attempt=$((attempt + 1))
+done
+
+echo "Waiting for Flannel pods to be ready (timeout: ${TIMEOUT}s)..."
+wait_output=$(kubectl wait --for=condition=ready pod -l app=flannel -n kube-flannel --timeout="${TIMEOUT}s" 2>&1) || {
+  echo "$wait_output"
+  dump_pod_status "kube-flannel" "Flannel"
+  diagnose_failure "Flannel" "$wait_output"
+  exit 1
+}
+echo "$wait_output"
+
+kubectl get pods -n kube-flannel
+echo "Flannel CNI $FLANNEL_VERSION installed successfully!"


### PR DESCRIPTION
## Summary

- Adds a new `cniPlugin` input (`calico`, `cilium`, `flannel`, `none`) to let users choose their CNI plugin when `disableDefaultCni: true`
- Creates `install-cilium.sh` that installs the Cilium CLI, runs `cilium install`, and waits for readiness via `cilium status --wait`
- Creates `install-flannel.sh` that applies the official Flannel manifest and waits for pods to be ready
- Adds `flannelVersion` input (default `v0.26.7`) with GitHub release validation
- Deprecates the `installCalico` boolean in favor of the new `cniPlugin` enum
- When `cniPlugin: none`, skips all CNI installation (equivalent to the old `installCalico: false`)
- Updates dry-run summary and deployment summary to reflect the selected CNI

## Usage

```yaml
# Use Cilium instead of Calico
- uses: palmsoftware/quick-k8s@v0
  with:
    cniPlugin: cilium

# Use Flannel
- uses: palmsoftware/quick-k8s@v0
  with:
    cniPlugin: flannel
    flannelVersion: v0.26.7

# Bring your own CNI
- uses: palmsoftware/quick-k8s@v0
  with:
    cniPlugin: none
```

## Test plan

- [ ] CI lint job passes (shellcheck on new scripts)
- [ ] Existing Calico tests continue to pass (default `cniPlugin: calico`)
- [ ] Input validation rejects invalid `cniPlugin` values
- [ ] `cniPlugin: none` skips CNI installation correctly

Closes #234