### PR TITLE
Add post-run cleanup handler for cluster teardown

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -617,6 +617,15 @@ runs:
           exit 1
         fi
 
+    - name: Validate enableCleanup input
+      shell: bash
+      run: |
+        if [[ "${{ inputs.enableCleanup }}" != "true" && "${{ inputs.enableCleanup }}" != "false" ]]; then
+          echo "Invalid enableCleanup value: ${{ inputs.enableCleanup }}"
+          echo "Must be 'true' or 'false'"
+          exit 1
+        fi
+
     - name: Validate dryRun input
       shell: bash
       env:
@@ -1335,6 +1344,9 @@ runs:
         echo "  Context:     $CONTEXT"
         if [ "$INSTALL_LOCAL_REGISTRY" = "true" ]; then
           echo "  Registry:    localhost:$LOCAL_REGISTRY_PORT"
+        fi
+        if [ "${{ inputs.enableCleanup }}" = "true" ]; then
+          echo "  Cleanup:     /tmp/quick-k8s-cleanup.sh"
         fi
         echo ""
         kubectl get nodes 2>/dev/null || true

--- a/scripts/cleanup-cluster.sh
+++ b/scripts/cleanup-cluster.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+# Script to clean up Kubernetes cluster resources created by quick-k8s
+#
+# Reads configuration from environment variables set during action execution:
+#   QUICK_K8S_PROVIDER     - Cluster provider (kind, minikube, k3s)
+#   QUICK_K8S_CLUSTER_NAME - Name of the cluster
+#
+# This script is copied to /tmp/quick-k8s-cleanup.sh during action setup.
+# Add to your workflow as a post-job cleanup step:
+#
+#   - name: Cleanup cluster
+#     if: always()
+#     run: /tmp/quick-k8s-cleanup.sh
+#
+# The script is intentionally lenient with errors — cleanup should never
+# cause a workflow failure.
+
+PROVIDER="${QUICK_K8S_PROVIDER:-}"
+CLUSTER_NAME="${QUICK_K8S_CLUSTER_NAME:-}"
+
+if [ -z "$PROVIDER" ]; then
+  echo "QUICK_K8S_PROVIDER not set, skipping cleanup"
+  exit 0
+fi
+
+if [ -z "$CLUSTER_NAME" ]; then
+  echo "QUICK_K8S_CLUSTER_NAME not set, skipping cleanup"
+  exit 0
+fi
+
+echo "::group::Quick-K8s Cluster Cleanup"
+
+echo "Cleaning up $PROVIDER cluster '$CLUSTER_NAME'..."
+
+case "$PROVIDER" in
+  kind)
+    if command -v kind &>/dev/null; then
+      echo "Deleting KinD cluster '$CLUSTER_NAME'..."
+      kind delete cluster --name "$CLUSTER_NAME" 2>/dev/null || true
+      echo "KinD cluster deleted"
+    else
+      echo "KinD binary not found, skipping cluster deletion"
+    fi
+    ;;
+  minikube)
+    if command -v minikube &>/dev/null; then
+      echo "Deleting Minikube cluster '$CLUSTER_NAME'..."
+      if [ "$CLUSTER_NAME" != "minikube" ]; then
+        minikube delete --profile "$CLUSTER_NAME" 2>/dev/null || true
+      else
+        minikube delete 2>/dev/null || true
+      fi
+      echo "Minikube cluster deleted"
+    else
+      echo "Minikube binary not found, skipping cluster deletion"
+    fi
+    ;;
+  k3s)
+    echo "Stopping k3s..."
+    if [ -x /usr/local/bin/k3s-killall.sh ]; then
+      /usr/local/bin/k3s-killall.sh 2>/dev/null || true
+    fi
+    if [ -x /usr/local/bin/k3s-uninstall.sh ]; then
+      /usr/local/bin/k3s-uninstall.sh 2>/dev/null || true
+    fi
+    echo "k3s stopped and uninstalled"
+    ;;
+  *)
+    echo "Unknown provider '$PROVIDER', skipping cluster cleanup"
+    ;;
+esac
+
+# Clean up local registry container if it exists
+REGISTRY_NAME="quick-k8s-registry"
+if command -v docker &>/dev/null; then
+  if docker ps -a --format '{{.Names}}' 2>/dev/null | grep -q "^${REGISTRY_NAME}$"; then
+    echo "Removing local registry container..."
+    docker rm -f "$REGISTRY_NAME" 2>/dev/null || true
+  fi
+fi
+
+# Remove temporary files created by the action
+echo "Removing temporary files..."
+rm -f /tmp/quick-k8s-cleanup.sh 2>/dev/null || true
+
+echo "::endgroup::"
+echo "Cluster cleanup complete"


### PR DESCRIPTION
## Summary

- Add `enableCleanup` input (boolean, default `true`) that prepares post-run cleanup resources
- Create `scripts/cleanup-cluster.sh` to handle cluster teardown for KinD, Minikube, and k3s providers
- Export cluster state (`QUICK_K8S_PROVIDER`, `QUICK_K8S_CLUSTER_NAME`) to `GITHUB_ENV` and copy cleanup script to `/tmp/quick-k8s-cleanup.sh`

## Design

GitHub composite actions do not support native `post:` lifecycle hooks ([actions/runner#1478](https://github.com/actions/runner/issues/1478)). Instead, the action prepares cleanup resources that users reference in their own workflow:

```yaml
- uses: palmsoftware/quick-k8s@v0
  with:
    enableCleanup: 'true'  # default

# ... your test steps ...

- name: Cleanup cluster
  if: always()
  run: /tmp/quick-k8s-cleanup.sh
```

The cleanup script:
- Deletes KinD clusters via `kind delete cluster --name <name>`
- Deletes Minikube clusters via `minikube delete --profile <name>`
- Stops and uninstalls k3s via `k3s-killall.sh` / `k3s-uninstall.sh` (future-proofing)
- Removes the local registry container (`quick-k8s-registry`) if present
- Is intentionally lenient with errors so cleanup never causes workflow failures
- Respects the `dryRun` guard (cleanup resources are not prepared in dry-run mode)

Closes #228

## Test plan

- [ ] Verify lint passes (shellcheck on all scripts)
- [ ] Verify existing CI matrix tests pass (cleanup script is additive, does not change default behavior)
- [ ] Verify `enableCleanup: 'true'` exports env vars and copies cleanup script
- [ ] Verify `enableCleanup: 'false'` skips cleanup preparation
- [ ] Verify dry-run summary includes cleanup status