### PR TITLE
fix: Fall back to Minikube max supported K8s version

### DIFF
--- a/scripts/start-minikube.sh
+++ b/scripts/start-minikube.sh
@@ -29,7 +29,7 @@ K8S_VERSION=$(echo "$NODE_IMAGE" | sed -E 's/.*:([^@]+)@.*/\1/')
 echo "Extracted Kubernetes version: $K8S_VERSION"
 
 # Validate that the extracted K8s version is supported by this Minikube binary
-MINIKUBE_DEFAULT_K8S=$(minikube config defaults kubernetes-version 2>/dev/null | tr -d '[:space:]')
+MINIKUBE_DEFAULT_K8S=$(minikube config defaults kubernetes-version 2>/dev/null | tr -d '[:space:]' || true)
 if [ -n "$MINIKUBE_DEFAULT_K8S" ]; then
   HIGHEST=$(printf '%s\n%s\n' "$K8S_VERSION" "$MINIKUBE_DEFAULT_K8S" | sort -V | tail -n1)
   if [ "$HIGHEST" != "$MINIKUBE_DEFAULT_K8S" ]; then

--- a/scripts/start-minikube.sh
+++ b/scripts/start-minikube.sh
@@ -28,6 +28,18 @@ trap 'echo "::endgroup::"' EXIT
 K8S_VERSION=$(echo "$NODE_IMAGE" | sed -E 's/.*:([^@]+)@.*/\1/')
 echo "Extracted Kubernetes version: $K8S_VERSION"
 
+# Validate that the extracted K8s version is supported by this Minikube binary
+MINIKUBE_DEFAULT_K8S=$(minikube config defaults kubernetes-version 2>/dev/null | tr -d '[:space:]')
+if [ -n "$MINIKUBE_DEFAULT_K8S" ]; then
+  HIGHEST=$(printf '%s\n%s\n' "$K8S_VERSION" "$MINIKUBE_DEFAULT_K8S" | sort -V | tail -n1)
+  if [ "$HIGHEST" != "$MINIKUBE_DEFAULT_K8S" ]; then
+    echo "::warning::Minikube does not support Kubernetes $K8S_VERSION (max supported: $MINIKUBE_DEFAULT_K8S). Falling back to $MINIKUBE_DEFAULT_K8S."
+    K8S_VERSION="$MINIKUBE_DEFAULT_K8S"
+  fi
+else
+  echo "::warning::Unable to query Minikube's supported Kubernetes versions. Proceeding with $K8S_VERSION."
+fi
+
 # Build minikube start command with appropriate flags
 MINIKUBE_CMD="minikube start"
 MINIKUBE_CMD="$MINIKUBE_CMD --driver=$DRIVER"


### PR DESCRIPTION
## Summary

- When the `defaultNodeImage` (a KinD image tag like `kindest/node:v1.36.1`) contains a Kubernetes version newer than what the installed Minikube binary supports, `start-minikube.sh` now falls back to Minikube's latest supported version instead of failing
- Queries `minikube config defaults kubernetes-version` to discover the max supported version, compares with `sort -V`, and emits a `::warning::` annotation when falling back
- Fixes the nightly CI failure: https://github.com/palmsoftware/quick-k8s/actions/runs/29466030101/job/87627595537

## Test plan

- [ ] `make lint` passes (shellcheck)
- [ ] Minikube CI tests pass with the current `defaultNodeImage` (v1.36.1) by falling back to v1.35.1
- [ ] KinD CI tests unaffected (this code path only runs for Minikube)