### PR TITLE
fix: Handle OLM catalog pod recreation during wait

### DIFF
--- a/scripts/install-olm.sh
+++ b/scripts/install-olm.sh
@@ -39,23 +39,52 @@ echo "$install_output"
 rm -f install.sh
 
 echo "Waiting for OLM pods to be ready..."
-wait_output=$(kubectl wait --for=condition=ready pod --all --namespace=olm --timeout="${TIMEOUT}s" 2>&1) || {
-  echo "$wait_output"
+# Use a retry loop instead of a single kubectl wait because OLM catalog
+# source pods can be recreated during startup, causing kubectl wait --all
+# to fail on the deleted pod even when all current pods are ready.
+olm_end_time=$((SECONDS + TIMEOUT))
+olm_ready=false
+while [ $SECONDS -lt $olm_end_time ]; do
+  remaining=$((olm_end_time - SECONDS))
+  if [ "$remaining" -le 0 ]; then
+    break
+  fi
+  wait_timeout=$((remaining < 30 ? remaining : 30))
+  if kubectl wait --for=condition=ready pod --all --namespace=olm --timeout="${wait_timeout}s" 2>/dev/null; then
+    olm_ready=true
+    break
+  fi
+  sleep 5
+done
+if [ "$olm_ready" != "true" ]; then
   dump_pod_status "olm" "OLM"
-  diagnose_failure "OLM" "$wait_output"
+  diagnose_failure "OLM" "OLM pods not ready after ${TIMEOUT}s"
   exit 1
-}
-echo "$wait_output"
+fi
+echo "All OLM pods in namespace olm are ready"
 
 pod_count=$(kubectl get pods --namespace=operators --no-headers 2>/dev/null | wc -l)
 if [ "$pod_count" -gt 0 ]; then
-  wait_output=$(kubectl wait --for=condition=ready pod --all --namespace=operators --timeout="${TIMEOUT}s" 2>&1) || {
-    echo "$wait_output"
+  ops_end_time=$((SECONDS + TIMEOUT))
+  ops_ready=false
+  while [ $SECONDS -lt $ops_end_time ]; do
+    remaining=$((ops_end_time - SECONDS))
+    if [ "$remaining" -le 0 ]; then
+      break
+    fi
+    wait_timeout=$((remaining < 30 ? remaining : 30))
+    if kubectl wait --for=condition=ready pod --all --namespace=operators --timeout="${wait_timeout}s" 2>/dev/null; then
+      ops_ready=true
+      break
+    fi
+    sleep 5
+  done
+  if [ "$ops_ready" != "true" ]; then
     dump_pod_status "operators" "OLM operators"
-    diagnose_failure "OLM" "$wait_output"
+    diagnose_failure "OLM" "OLM operator pods not ready after ${TIMEOUT}s"
     exit 1
-  }
-  echo "$wait_output"
+  fi
+  echo "All OLM pods in namespace operators are ready"
 else
   echo "No pods in operators namespace (expected — pods appear when operators are installed)"
 fi


### PR DESCRIPTION
## Summary

- Replace single kubectl wait --all with a retry loop (30s iterations) that re-evaluates current pods each cycle
- Fixes false timeout when OLM catalog source pods are recreated during startup

## Problem

kubectl wait --for=condition=ready pod --all resolves pod names at invocation time. When OLM operatorhubio-catalog pod is recreated during startup (e.g., 5ct5w replaced by t596v), the wait keeps tracking the deleted pod and times out -- even though all current pods are Running/Ready.

Observed in [certsuite CI](https://github.com/redhat-best-practices-for-k8s/certsuite/actions/runs/30286892394/job/90048529789?pr=3813):

```
timed out waiting for the condition on pods/operatorhubio-catalog-5ct5w  <-- deleted
timed out waiting for the condition on pods/operatorhubio-catalog-t596v  <-- actually Running 1/1
```

## Fix

Use a retry loop with 30s kubectl wait iterations within the overall COMPONENT_TIMEOUT. Each iteration re-resolves --all to current pods, so pod recreation is handled gracefully. Applied to both olm and operators namespace waits.

## Test plan

- [ ] CI matrix passes (KinD, Minikube, k3s with OLM enabled)
- [ ] Verify OLM pods reach Ready state in CI logs