### PR TITLE
refactor: Extract wait_for_pods_ready into shared utility

### DIFF
--- a/scripts/diagnose-failure.sh
+++ b/scripts/diagnose-failure.sh
@@ -71,6 +71,28 @@ diagnose_failure() {
   fi
 }
 
+# Waits for pods to be ready with retry, handling pod recreation during startup.
+# Usage: wait_for_pods_ready <namespace> <component_label> <timeout> [kubectl_wait_args...]
+wait_for_pods_ready() {
+  local namespace="$1" component="$2" timeout="$3"
+  shift 3
+  local end_time=$((SECONDS + timeout)) last_err=""
+  while [ $SECONDS -lt $end_time ]; do
+    local remaining=$((end_time - SECONDS))
+    local wait_timeout=$((remaining < 30 ? remaining : 30))
+    last_err=$(kubectl wait --for=condition=ready pod --namespace="$namespace" \
+      --timeout="${wait_timeout}s" "$@" 2>&1) && {
+      echo "All pods in namespace $namespace are ready"
+      return 0
+    }
+    sleep 5
+  done
+  echo "$last_err"
+  dump_pod_status "$namespace" "$component"
+  diagnose_failure "$component" "$last_err"
+  return 1
+}
+
 # Collects pod status from a namespace to add context to failure diagnostics.
 # Call after a kubectl wait failure to show what went wrong.
 dump_pod_status() {

--- a/scripts/install-olm.sh
+++ b/scripts/install-olm.sh
@@ -39,52 +39,11 @@ echo "$install_output"
 rm -f install.sh
 
 echo "Waiting for OLM pods to be ready..."
-# Use a retry loop instead of a single kubectl wait because OLM catalog
-# source pods can be recreated during startup, causing kubectl wait --all
-# to fail on the deleted pod even when all current pods are ready.
-olm_end_time=$((SECONDS + TIMEOUT))
-olm_ready=false
-while [ $SECONDS -lt $olm_end_time ]; do
-  remaining=$((olm_end_time - SECONDS))
-  if [ "$remaining" -le 0 ]; then
-    break
-  fi
-  wait_timeout=$((remaining < 30 ? remaining : 30))
-  if kubectl wait --for=condition=ready pod --all --namespace=olm --timeout="${wait_timeout}s" 2>/dev/null; then
-    olm_ready=true
-    break
-  fi
-  sleep 5
-done
-if [ "$olm_ready" != "true" ]; then
-  dump_pod_status "olm" "OLM"
-  diagnose_failure "OLM" "OLM pods not ready after ${TIMEOUT}s"
-  exit 1
-fi
-echo "All OLM pods in namespace olm are ready"
+wait_for_pods_ready "olm" "OLM" "$TIMEOUT" --all || exit 1
 
 pod_count=$(kubectl get pods --namespace=operators --no-headers 2>/dev/null | wc -l)
 if [ "$pod_count" -gt 0 ]; then
-  ops_end_time=$((SECONDS + TIMEOUT))
-  ops_ready=false
-  while [ $SECONDS -lt $ops_end_time ]; do
-    remaining=$((ops_end_time - SECONDS))
-    if [ "$remaining" -le 0 ]; then
-      break
-    fi
-    wait_timeout=$((remaining < 30 ? remaining : 30))
-    if kubectl wait --for=condition=ready pod --all --namespace=operators --timeout="${wait_timeout}s" 2>/dev/null; then
-      ops_ready=true
-      break
-    fi
-    sleep 5
-  done
-  if [ "$ops_ready" != "true" ]; then
-    dump_pod_status "operators" "OLM operators"
-    diagnose_failure "OLM" "OLM operator pods not ready after ${TIMEOUT}s"
-    exit 1
-  fi
-  echo "All OLM pods in namespace operators are ready"
+  wait_for_pods_ready "operators" "OLM operators" "$TIMEOUT" --all || exit 1
 else
   echo "No pods in operators namespace (expected — pods appear when operators are installed)"
 fi


### PR DESCRIPTION
## Summary

- Extract the retry-wait loop from install-olm.sh into a reusable `wait_for_pods_ready` function in diagnose-failure.sh
- Eliminates duplicated 19-line retry loops (two copies become two one-liners)
- Preserves kubectl stderr on failure for diagnostics (previous version suppressed it with `2>/dev/null`)
- Removes dead `remaining <= 0` guard that could never trigger
- Available to all install scripts that already source diagnose-failure.sh

Follows up on #339 which introduced the retry loop.

## Test plan

- [ ] CI matrix passes (KinD, Minikube, k3s with OLM enabled)