### PR TITLE
fix: Scale down monitoring stack replicas for CI runners

### DIFF
--- a/scripts/install-prometheus.sh
+++ b/scripts/install-prometheus.sh
@@ -61,6 +61,16 @@ if [ -f "$GRAFANA_DEPLOY" ]; then
   sed -i 's/replicas: 1/replicas: 0/' "$GRAFANA_DEPLOY"
 fi
 
+echo "Scaling down HA replicas (CI doesn't need high-availability)..."
+for manifest_file in \
+  "${KUBE_PROMETHEUS_DIR}/manifests/alertmanager-alertmanager.yaml" \
+  "${KUBE_PROMETHEUS_DIR}/manifests/prometheus-prometheus.yaml" \
+  "${KUBE_PROMETHEUS_DIR}/manifests/prometheusAdapter-deployment.yaml"; do
+  if [ -f "$manifest_file" ]; then
+    sed -i 's/replicas: [23]/replicas: 1/' "$manifest_file"
+  fi
+done
+
 echo "Applying kube-prometheus setup manifests (CRDs, namespace)..."
 setup_output=$(kubectl apply --server-side --timeout=5m -f "${KUBE_PROMETHEUS_DIR}/manifests/setup/" 2>&1) || {
   echo "$setup_output"


### PR DESCRIPTION
## Summary
- Scale down alertmanager (3->1), prometheus (2->1), and prometheus-adapter (2->1) replicas in kube-prometheus manifests before applying
- The monitoring-tests nightly job with minikube has been failing ~67% of the time due to resource exhaustion on free-tier CI runners
- Two failure modes: pods not becoming ready within 300s timeout, and Thanos-triggered Prometheus StatefulSet rollout timing out
- KinD handles the full HA stack fine (93% pass rate) but minikube with Docker driver is more resource-constrained
- CI doesn't need high-availability — single replicas are sufficient to validate monitoring functionality

## Test plan
- [ ] `make lint` passes (verified locally)
- [ ] Trigger nightly workflow manually and verify monitoring-tests pass for minikube variants
- [ ] Verify monitoring-tests with KinD remain unaffected