### PR TITLE
fix: Force-delete Prometheus pods during Thanos sidecar rollout

### DIFF
--- a/scripts/install-thanos.sh
+++ b/scripts/install-thanos.sh
@@ -135,7 +135,9 @@ EOF
 }
 echo "$apply_output"
 
-echo "Waiting for Prometheus to restart with Thanos sidecar..."
+echo "Restarting Prometheus pods to pick up Thanos sidecar..."
+kubectl delete pods -n monitoring -l app.kubernetes.io/name=prometheus --grace-period=30 --wait=false
+sleep 5
 rollout_output=$(kubectl rollout status statefulset/prometheus-k8s -n monitoring --timeout="${TIMEOUT}s" 2>&1) || {
   echo "$rollout_output"
   dump_pod_status "monitoring" "Thanos/Prometheus"


### PR DESCRIPTION
## Summary
- Follow-up to #342 which scaled down HA replicas
- The Prometheus StatefulSet rolling update still hangs on pod termination during Thanos sidecar injection on minikube CI runners (ubuntu-22.04)
- Instead of waiting for the slow graceful termination, delete the prometheus pods with a 30s grace period so they restart quickly with the sidecar
- This eliminates the last remaining monitoring-tests failure

## Test plan
- [ ] `make lint` passes (verified locally)
- [ ] PR CI `test-cluster-monitoring` job passes
- [ ] Trigger nightly workflow after merge and verify all 6 monitoring-tests pass