### PR TITLE
docs: Fix version drift, stale references, missing inputs, and add Flannel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**quick-k8s** is a GitHub Action for deploying Kubernetes clusters on GitHub Actions runners. It's a composite action using shell scripts that supports KinD (Kubernetes in Docker), Minikube, and k3s as cluster providers, with optional Calico CNI, Istio service mesh, OLM (Operator Lifecycle Manager), and local Docker registry.
+**quick-k8s** is a GitHub Action for deploying Kubernetes clusters on GitHub Actions runners. It's a composite action using shell scripts that supports KinD (Kubernetes in Docker) and Minikube as cluster providers, with optional CNI (Calico, Cilium, or Flannel), Istio service mesh, OLM (Operator Lifecycle Manager), and local Docker registry.
 
 **Target Environment**: Linux (Ubuntu 22.04/24.04/26.04, x86 and ARM64).
 
@@ -29,19 +29,19 @@ The action executes in sequence via `action.yml`:
 1. **Input validation** - Validates all inputs (versions, providers, ports, node counts)
 2. **GitHub status check** - Verifies GitHub services are operational
 3. **Disk optimization** - Uses `palmsoftware/quick-cleanup` for adaptive disk management
-4. **Binary installation** - Installs KinD, Minikube, or k3s (with caching)
+4. **Binary installation** - Installs KinD or Minikube (with caching)
 5. **Cluster creation** - Creates cluster using generated or custom config
-6. **CNI installation** - Installs Calico (optional, can be skipped for bring-your-own-CNI)
+6. **CNI installation** - Installs Calico, Cilium, or Flannel (optional, can be skipped for bring-your-own-CNI)
 7. **Optional features** - OLM, Istio, local registry
 8. **Cleanup** - Removes temporary files
 
 ### Script Organization (`/scripts/`)
 
 Each script handles a single responsibility:
-- `install-kind.sh`, `install-minikube.sh`, `install-k3s.sh` - Binary installation with fallback URLs
+- `install-kind.sh`, `install-minikube.sh` - Binary installation with fallback URLs
 - `generate-kind-config.sh` - Creates KinD YAML config from action inputs
 - `start-minikube.sh` - Starts Minikube with appropriate flags
-- `install-calico.sh`, `install-istio.sh`, `install-olm.sh` - Component installers
+- `install-calico.sh`, `install-cilium.sh`, `install-flannel.sh`, `install-istio.sh`, `install-olm.sh`, `install-metallb.sh` - Component installers
 - `setup-local-registry.sh` - Docker registry setup with cluster connectivity
 - `pre-cluster-optimization.sh` - Disk space management
 - `check-github-status.sh` - GitHub API availability check
@@ -49,11 +49,9 @@ Each script handles a single responsibility:
 ### Version Management
 
 Nightly workflows auto-update dependency versions in `action.yml`:
-- `calico-update.yml` - Calico CNI
-- `istio-update.yml` - Istio service mesh
+- `version-updates.yml` - Calico, Istio, Minikube, cert-manager, ingress-nginx, metrics-server
 - `olm-update.yml` - Operator Lifecycle Manager
-- `minikube-update.yml` - Minikube
-- `k3s-update.yml` - k3s
+- `kind-node-image-update.yml` - KinD default node image
 
 Updates fetch latest versions from GitHub API, validate semver format, and create PRs via `peter-evans/create-pull-request`.
 
@@ -83,21 +81,12 @@ Minikube extracts K8s version from the node image tag:
 K8S_VERSION=$(echo "$NODE_IMAGE" | sed -E 's/.*:([^@]+)@.*/\1/')
 ```
 
-### k3s Specifics
-
-k3s runs as native processes (not in Docker) on the host:
-- **Version format**: `v1.33.1+k3s1` — the `+` must be URL-encoded as `%2B` in GitHub API/download URLs
-- **Single control plane**: Multi-CP requires embedded etcd, not yet supported
-- **Built-in Traefik/ServiceLB disabled**: To avoid conflicts with action's ingress support
-- **Storage class**: Uses `local-path` (not `standard` like KinD/Minikube)
-- **Multi-node**: Worker nodes run as separate `k3s agent` processes with unique `--data-dir`
-
 ## CI Workflows
 
 ### `pre-main.yml` - Primary CI
 - Triggers: Push to main, PRs, manual dispatch
 - **Lint job blocks all other jobs** - Must pass before tests run
-- Matrix: 4 OS (ubuntu-{22,24}.04 × {x86,arm}) × 3 providers (KinD, Minikube, k3s)
+- Matrix: 4 OS (ubuntu-{22,24}.04 × {x86,arm}) × 2 providers (KinD, Minikube)
 - Tests: Basic cluster, OLM, Istio, local registry, custom config, CNI skip
 
 ### `nightly.yml` - Extended Testing

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -4,13 +4,13 @@ This document lists tested and known-compatible version combinations for quick-k
 
 ## Component Compatibility
 
-| Kubernetes | Calico | Cilium | Istio | cert-manager | OLM | MetalLB | Notes |
-|------------|--------|--------|-------|--------------|-----|---------|-------|
-| 1.36.x | v3.32+ | v1.17+ | 1.30+ | v1.20+ | v0.31+ | v0.15+ | Current default |
-| 1.35.x | v3.31+ | v1.16+ | 1.29+ | v1.19+ | v0.30+ | v0.14+ | Fully tested |
-| 1.34.x | v3.30+ | v1.15+ | 1.28+ | v1.18+ | v0.29+ | v0.14+ | Fully tested |
-| 1.33.x | v3.29+ | v1.14+ | 1.27+ | v1.17+ | v0.28+ | v0.13+ | Compatible |
-| <1.31 | v3.28.x | v1.14+ | 1.26+ | v1.16+ | v0.27+ | v0.13+ | See notes below |
+| Kubernetes | Calico | Cilium | Flannel | Istio | cert-manager | OLM | MetalLB | Notes |
+|------------|--------|--------|---------|-------|--------------|-----|---------|-------|
+| 1.36.x | v3.32+ | v1.17+ | v0.28+ | 1.30+ | v1.20+ | v0.31+ | v0.15+ | Current default |
+| 1.35.x | v3.31+ | v1.16+ | v0.27+ | 1.29+ | v1.19+ | v0.30+ | v0.14+ | Fully tested |
+| 1.34.x | v3.30+ | v1.15+ | v0.26+ | 1.28+ | v1.18+ | v0.29+ | v0.14+ | Fully tested |
+| 1.33.x | v3.29+ | v1.14+ | v0.25+ | 1.27+ | v1.17+ | v0.28+ | v0.13+ | Compatible |
+| <1.31 | v3.28.x | v1.14+ | v0.24+ | 1.26+ | v1.16+ | v0.27+ | v0.13+ | See notes below |
 
 ## Known Issues and Workarounds
 
@@ -28,6 +28,10 @@ Minikube may not support the very latest Kubernetes version. When the `defaultNo
 
 OLM v0.31+ is recommended for Kubernetes 1.36+. Older OLM versions may encounter API compatibility issues with newer Kubernetes releases.
 
+### Flannel
+
+Flannel is a simple overlay network that provides basic pod-to-pod connectivity. It does **not** support Kubernetes NetworkPolicy — if you need network policy enforcement, use Calico or Cilium instead. Flannel is currently supported with KinD only (`clusterProvider: kind`).
+
 ### Istio Profile Resource Usage
 
 | Profile | Memory | CPU | Best For |
@@ -40,7 +44,7 @@ OLM v0.31+ is recommended for Kubernetes 1.36+. Older OLM versions may encounter
 
 ## CI Test Matrix
 
-The following combinations are tested nightly:
+Cilium and Flannel are tested in `pre-main.yml` (PR and push CI). The following combinations are tested nightly:
 
 | Runner | Provider | Configuration |
 |--------|----------|--------------|
@@ -62,4 +66,5 @@ The following combinations are tested nightly:
 - [Istio supported releases](https://istio.io/latest/docs/releases/supported-releases/)
 - [cert-manager supported releases](https://cert-manager.io/docs/releases/)
 - [OLM releases](https://github.com/operator-framework/operator-lifecycle-manager/releases)
+- [Flannel releases](https://github.com/flannel-io/flannel/releases)
 - [MetalLB releases](https://github.com/metallb/metallb/releases)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ steps:
       workerNodeLabels: ''          # Comma-separated key=value labels for worker nodes
       installOLM: false
       installIstio: false
-      istioVersion: 1.30.2
+      istioVersion: 1.30.3
       istioProfile: minimal
       installCertManager: false
       certManagerVersion: v1.21.0
@@ -86,7 +86,7 @@ steps:
       # Monitoring
       enableClusterMonitoring: false
       kubePrometheusVersion: v0.18.0
-      thanosVersion: v0.42.0
+      thanosVersion: v0.42.2
 
       # MetalLB
       installMetalLB: false
@@ -97,13 +97,19 @@ steps:
       kindConfigPath: ''            # Path to custom KinD config file
       installLocalRegistry: false   # Enable local Docker registry
       localRegistryPort: 5001       # Port for local registry
-      olmVersion: v0.45.0           # OLM version (when installOLM: true)
+      olmVersion: v0.46.0           # OLM version (when installOLM: true)
       createPersistentVolumes: false # Create sample PVs for testing
       persistentVolumeCount: 5
       persistentVolumeSize: 10Gi
       installSampleNetworkPolicies: false
       waitForPodsTimeout: 1200      # Pod readiness timeout in seconds
       dryRun: false                 # Preview configuration without executing
+      controlPlaneTaints: ''        # Comma-separated taints for control-plane nodes
+      workerNodeTaints: ''          # Comma-separated taints for worker nodes
+      extraPortMappings: ''         # Comma-separated host:container port mappings (KinD only)
+      componentTimeout: 300         # Timeout in seconds for component installs
+      enableCleanup: false          # Generate cleanup script at /tmp/quick-k8s-cleanup.sh
+      flannelVersion: v0.28.7      # Flannel version (when cniPlugin is flannel)
 ```
 
 With Minikube:
@@ -126,7 +132,7 @@ steps:
       workerNodeLabels: ''          # Comma-separated key=value labels for worker nodes
       installOLM: false
       installIstio: false
-      istioVersion: 1.30.2
+      istioVersion: 1.30.3
       istioProfile: minimal
       installCertManager: false
       certManagerVersion: v1.21.0
@@ -152,7 +158,7 @@ steps:
     uses: palmsoftware/quick-k8s@v0
     with:
       installIstio: true
-      istioVersion: 1.30.2
+      istioVersion: 1.30.3
       istioProfile: minimal
 ```
 
@@ -383,7 +389,7 @@ steps:
     with:
       enableClusterMonitoring: true
       kubePrometheusVersion: v0.18.0
-      thanosVersion: v0.42.0
+      thanosVersion: v0.42.2
 ```
 
 **Features**:
@@ -450,21 +456,21 @@ steps:
 |------------|----------|-----------------|----------------|
 | **Calico** (default) | General purpose, policy enforcement | ✅ Full support | ~200MB |
 | **Cilium** | eBPF-based networking, advanced observability | ✅ Full support | ~300-500MB |
-| **Flannel** | Simple overlay networking, minimal overhead | ❌ Not supported | ~100MB |
+| **Flannel** | Simple overlay networking, minimal overhead | ⚠️ KinD only | ~100MB |
 | **none** | Bring your own CNI | Depends on CNI | N/A |
 
-### Bring Your Own CNI (Skip Calico)
+### Bring Your Own CNI
 
-For projects that need to install their own CNI (e.g., Multus, OVN-Kubernetes, Cilium), you can skip the default Calico installation:
+For projects that need to install their own CNI (e.g., Multus, OVN-Kubernetes), you can skip the default CNI installation:
 
 ```yaml
 steps:
-  - name: Set up Quick-K8s without Calico
+  - name: Set up Quick-K8s without CNI
     uses: palmsoftware/quick-k8s@v0
     with:
       disableDefaultCni: true
-      installCalico: false  # Skip Calico installation
-      waitForPodsReady: false  # Don't wait - no CNI means pods won't be ready
+      cniPlugin: none             # Skip CNI installation
+      waitForPodsReady: false     # Don't wait - no CNI means pods won't be ready
 
   - name: Install your own CNI
     run: |
@@ -473,7 +479,7 @@ steps:
 ```
 
 **⚠️ Important Notes**:
-- When `installCalico: false`, the cluster will not have a functional CNI
+- When `cniPlugin: none`, the cluster will not have a functional CNI
 - Pods will remain in `Pending` state until you install a CNI
 - Set `waitForPodsReady: false` to avoid timeouts waiting for pods
 - This is ideal for projects testing their own CNI implementations


### PR DESCRIPTION
## Summary

- **README.md**: Update stale version examples to match `action.yml` defaults (istio 1.30.3, thanos v0.42.2, olm v0.46.0). Add 6 missing inputs to Complete Configuration block. Update "Bring Your Own CNI" section to use `cniPlugin: none` instead of deprecated `installCalico: false`. Fix Flannel Minikube support note.
- **CLAUDE.md**: Remove all k3s references (removed in PR #226). Fix workflow names to reflect consolidation into `version-updates.yml`. Add Cilium, Flannel, and MetalLB to script/component lists.
- **COMPATIBILITY.md**: Add Flannel column to version compatibility matrix. Add Flannel known issues section. Note Cilium/Flannel CI coverage. Add Flannel upstream reference link.

Closes #353, closes #354, closes #361, closes #362