### PR TITLE
fix: Standardize shebangs and remove dead KIND_CMD code

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -857,10 +857,6 @@ runs:
           echo "  Minikube Version: $MINIKUBE_VERSION"
           echo "  Driver: $MINIKUBE_DRIVER"
         fi
-        if [ -n "$EXTRA_PROVIDER_ARGS" ]; then
-          echo ""
-          echo "Extra Provider Args: $EXTRA_PROVIDER_ARGS"
-        fi
         echo ""
         echo "=============================================="
         echo "  Dry run complete - no changes were made"
@@ -1016,13 +1012,6 @@ runs:
         max_attempts=3
         delay=10
         attempt=1
-
-        # Build the base kind create command
-        KIND_CMD="kind create cluster --name ${{ inputs.clusterName }} --config ${{ github.action_path }}/kind-config.yaml"
-        if [ -n "$EXTRA_PROVIDER_ARGS" ]; then
-          echo "Appending extra provider args: $EXTRA_PROVIDER_ARGS"
-          KIND_CMD="$KIND_CMD $EXTRA_PROVIDER_ARGS"
-        fi
 
         while [ $attempt -le $max_attempts ]; do
           echo ""

--- a/scripts/generate-kind-config.sh
+++ b/scripts/generate-kind-config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Generate a KinD configuration file from parameters

--- a/scripts/label-worker-nodes.sh
+++ b/scripts/label-worker-nodes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Script to apply labels to worker nodes after cluster creation

--- a/scripts/pre-flight-check.sh
+++ b/scripts/pre-flight-check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check Docker is running
 if ! docker info >/dev/null 2>&1; then

--- a/scripts/remove-control-plane-taint.sh
+++ b/scripts/remove-control-plane-taint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Script to remove the control plane taint from the control-plane nodes

--- a/scripts/setup-local-registry.sh
+++ b/scripts/setup-local-registry.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Setup a local Docker registry accessible from the KinD/Minikube cluster
 # Usage: setup-local-registry.sh <port> <cluster-provider> [cluster-name]

--- a/scripts/wait-for-pods.sh
+++ b/scripts/wait-for-pods.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 echo "::group::Waiting for pods to be ready"


### PR DESCRIPTION
## Summary

- Standardize 6 scripts from `#!/bin/bash` to `#!/usr/bin/env bash` for consistency and portability — all other scripts already used `env bash`
- Remove dead `KIND_CMD` variable and `EXTRA_PROVIDER_ARGS` references from `action.yml` — `KIND_CMD` was built but never used (the actual `kind create cluster` call was hardcoded separately), and `EXTRA_PROVIDER_ARGS` was never set by any input or assignment

## Test plan

- [x] `make lint` passes (shellcheck on all scripts)
- [ ] CI validates no behavioral changes

Closes #355
Closes #359